### PR TITLE
Enable auto-discovery for the client connection generation

### DIFF
--- a/docs/.vuepress/components/Connection.vue
+++ b/docs/.vuepress/components/Connection.vue
@@ -1,68 +1,89 @@
 <template>
   <ClientOnly>
-    <el-form
-            label-width="240px"
-            :model="state"
-    >
-      <el-form-item label="Connect to:" prop="cluster">
-        <el-switch
-                v-model="cluster"
-                active-text="Cluster"
-                inactive-text="Single node">
-        </el-switch>
-      </el-form-item>
+    <div>
+      <p></p>
+      <el-form
+              label-width="240px"
+              :model="fetch"
+      >
+        <el-form-item label="Fetch configuration:" prop="from">
+          <el-radio-group v-model="fetch.from">
+            <el-radio-button label="cloud">Event Store Cloud</el-radio-button>
+            <el-radio-button label="url">Node URL</el-radio-button>
+            <el-radio-button label="manual">Specify manually</el-radio-button>
+          </el-radio-group>
+        </el-form-item>
+      </el-form>
 
-      <el-form-item label="Protocol security:" prop="secure">
-        <el-switch
-                v-model="secure"
-                :disabled="cloud"
-                active-text="Secure"
-                inactive-text="Insecure">
-        </el-switch>
-      </el-form-item>
+      <transition name="slide">
+        <cloud v-show="fetch.from === 'cloud'" @proceed="proceed"/>
+      </transition>
 
-      <Cloud/>
+      <transition name="slide">
+        <node-url v-show="fetch.from === 'url'" @proceed="proceed"/>
+      </transition>
 
-      <ClusterConnection/>
+      <el-form
+              label-width="240px"
+              :model="state"
+      >
+        <transition name="slide">
+          <manual v-show="showManual"/>
+        </transition>
+      </el-form>
 
       <h2>Connection string</h2>
       <p>Each SDK has its own way to configure the client, but it's always possible to use the connection string. The
-        connection string below is generated according to the configuration you specified above, and it should work with
+        connection string below is generated according to the configuration you specified above, and it should work
+        with
         each official SDK of EventStoreDB.</p>
 
-      <pre><code>{{ connectionString ? connectionString : "Fill out the form to get the connection string" }}</code></pre>
+      <pre><code>{{
+          connectionString ? connectionString : "Fill out the form to get the connection string"
+        }}</code></pre>
 
-    </el-form>
+    </div>
   </ClientOnly>
 </template>
 
 <script>
 import connection from "../store/client/connection";
-import ClusterConnection from "./client/ClusterConnection";
 import Cloud from "./client/Cloud";
-import {isTrue} from "../lib/parse";
 import {SubmitCodeBlock} from "../theme/store/mutations";
+import NodeUrl from "./client/NodeUrl";
+import Manual from "./client/Manual";
 
 export default {
     name:       "Connection",
-    components: {Cloud, ClusterConnection},
-    computed:   {
-        state:            () => connection,
-        cloud:            () => connection.cloud,
-        cluster:          connection.extendedProperty("cluster", "changeTopology"),
-        secure:           connection.extendedProperty("secure", "changeSecurity"),
-        connectionString: () => connection.connectionString,
-    },
-    mounted() {
-        connection.changeTopology(isTrue(this.$route.query.cluster));
-        connection.changeHosting(isTrue(this.$route.query.cloud));
-        if (this.$route.query.clusterId) {
-            connection.setClusterId(this.$route.query.clusterId);
+    components: {Manual, Cloud, NodeUrl},
+    data() {
+        return {
+            fetch: {
+                from: "cloud"
+            },
+            showConfig: false
         }
     },
+    computed:   {
+        state:            () => connection,
+        cluster:          connection.extendedProperty("cluster", "changeTopology"),
+        secure:           connection.extendedProperty("secure", "changeSecurity"),
+        showManual() {
+            return this.fetch.from === 'manual' || this.showConfig;
+        },
+        connectionString: () => connection.connectionString,
+    },
     watch:      {
+        "fetch.from"() {
+            this.showConfig = false;
+        },
         connectionString() {
             this.$store.commit(SubmitCodeBlock, {key: "connectionString", value: this.connectionString});
+        }
+    },
+    methods: {
+        proceed() {
+            this.showConfig = true;
         }
     }
 }

--- a/docs/.vuepress/components/Connection.vue
+++ b/docs/.vuepress/components/Connection.vue
@@ -16,7 +16,7 @@
       </el-form>
 
       <transition name="slide">
-        <cloud v-show="fetch.from === 'cloud'" @proceed="proceed"/>
+        <cloud v-show="fetch.from === 'cloud'" :cluster-id="clusterId" @proceed="proceed"/>
       </transition>
 
       <transition name="slide">
@@ -61,7 +61,8 @@ export default {
             fetch: {
                 from: "cloud"
             },
-            showConfig: false
+            showConfig: false,
+            clusterId: ""
         }
     },
     computed:   {
@@ -85,6 +86,10 @@ export default {
         proceed() {
             this.showConfig = true;
         }
+    },
+    mounted() {
+        const clusterId = this.$route.query.clusterId;
+        if (clusterId) this.clusterId = clusterId;
     }
 }
 </script>

--- a/docs/.vuepress/components/client/Cloud.vue
+++ b/docs/.vuepress/components/client/Cloud.vue
@@ -1,52 +1,87 @@
 <template>
   <ClientOnly>
-    <div>
-      <el-form-item label="Hosting model:" prop="cloud">
+    <el-form
+            label-width="240px"
+            :model="form"
+    >
+      <el-form-item
+              label="Cloud cluster ID:"
+              prop="clusterId"
+              ref="clusterForm"
+              :rules="[ { validator: validateAddress, required: true } ]"
+      >
         <el-col :span="10">
-          <el-switch
-                  v-model="cloud"
-                  inactive-text="Self-hosted"
-                  active-text="Event Store Cloud">
-          </el-switch>
+          <el-input
+                  placeholder="Cluster ID"
+                  v-model="form.clusterId"
+          />
         </el-col>
+
         <el-col :span="12" class="form-help">
-          Want to get ESDB maintained by people who built it?
-          Lean more about <a href="https://www.eventstore.com/event-store-cloud" target="_blank">Event Store Cloud</a>.
-          <badge>new</badge>
+          Find your cluster ID in the <a href="https://console.eventstore.cloud" target="_blank">Cloud Console</a>,
+          on the Cluster Details tab.
         </el-col>
       </el-form-item>
 
-      <transition name="slide">
-        <el-form-item
-                label="Cloud cluster ID:"
-                prop="clusterId"
-                v-show="cloud"
-        >
-          <el-col :span="10">
-            <el-input
-                    placeholder="Cluster ID"
-                    v-model="clusterId"
-            />
-          </el-col>
-          <el-col :span="12" class="form-help">
-            Find your cluster ID in the <a href="https://console.eventstore.cloud" target="_blank">Cloud Console</a>,
-            on the Cluster Details tab.
-          </el-col>
-        </el-form-item>
-      </transition>
-    </div>
+      <el-form-item>
+        <el-button icon="el-icon-magic-stick" type="primary" :disabled="disableFetch" @click="fetchConfig">
+          Fetch configuration
+        </el-button>
+      </el-form-item>
+    </el-form>
   </ClientOnly>
 </template>
 
 <script>
 import connection from "../../store/client/connection";
+import {resolveDns} from "../../lib/networks";
+import {error, ok} from "../../lib/validate";
 
 export default {
     name:     "Cloud",
-    computed: {
-        state:     () => connection,
-        cloud:     connection.extendedProperty("cloud", "changeHosting"),
-        clusterId: connection.extendedProperty("clusterId", "setClusterId")
+    data() {
+        return {
+            form:      {
+                clusterId: "",
+            },
+            addresses: []
+        }
     },
+    computed: {
+        conn: () => connection,
+        disableFetch() {
+            return this.form.clusterId === "";
+        },
+        dnsName() {
+            return `${this.form.clusterId}.mesdb.eventstore.cloud`;
+        }
+    },
+    watch:    {
+        "form.clusterId"() {
+            this.$refs.clusterForm.clearValidate();
+            this.addresses = [];
+        }
+    },
+    methods:  {
+        async fetchConfig() {
+            const addresses = await resolveDns(this.dnsName);
+            this.addresses  = addresses;
+            if (!addresses) {
+                this.$refs.clusterForm.validate();
+                return;
+            }
+
+            connection.changeHosting(true);
+            connection.setClusterId(this.form.clusterId);
+            connection.changeTopology(addresses.length > 1);
+
+            this.$emit("proceed");
+        },
+        validateAddress(rule, value, callback) {
+            return this.disableFetch || this.addresses
+                ? ok(callback)
+                : error(callback, `Unable to resolve the ${this.dnsName} DNS name`);
+        }
+    }
 }
 </script>

--- a/docs/.vuepress/components/client/Cloud.vue
+++ b/docs/.vuepress/components/client/Cloud.vue
@@ -39,6 +39,9 @@ import {error, ok} from "../../lib/validate";
 
 export default {
     name:     "Cloud",
+    props:    {
+        clusterId: String
+    },
     data() {
         return {
             form:      {
@@ -58,7 +61,9 @@ export default {
     },
     watch:    {
         "form.clusterId"() {
-            this.$refs.clusterForm.clearValidate();
+            if (this.$refs.clusterForm) {
+                this.$refs.clusterForm.clearValidate();
+            }
             this.addresses = [];
         }
     },
@@ -82,6 +87,10 @@ export default {
                 ? ok(callback)
                 : error(callback, `Unable to resolve the ${this.dnsName} DNS name`);
         }
+    },
+    async mounted() {
+        this.form.clusterId = this.clusterId;
+        if (this.clusterId !== "") await this.fetchConfig();
     }
 }
 </script>

--- a/docs/.vuepress/components/client/Manual.vue
+++ b/docs/.vuepress/components/client/Manual.vue
@@ -1,0 +1,49 @@
+<template>
+  <ClientOnly>
+    <el-form
+            label-width="240px"
+            :model="state"
+    >
+      <el-form-item label="Connect to:" prop="cluster">
+        <el-switch
+                v-model="cluster"
+                active-text="Cluster"
+                inactive-text="Single node">
+        </el-switch>
+      </el-form-item>
+
+      <el-form-item label="Protocol security:" prop="secure">
+        <el-switch
+                v-model="secure"
+                :disabled="disableSecurity"
+                active-text="Secure"
+                inactive-text="Insecure">
+        </el-switch>
+      </el-form-item>
+
+      <ClusterConnection/>
+
+    </el-form>
+  </ClientOnly>
+</template>
+
+<script>
+import connection from "../../store/client/connection";
+import ClusterConnection from "./../client/ClusterConnection";
+import {isTrue} from "../../lib/parse";
+
+export default {
+    name:       "Manual",
+    components: {ClusterConnection},
+    computed:   {
+        state:           () => connection,
+        disableSecurity: () => connection.cloud,
+        cluster:         connection.extendedProperty("cluster", "changeTopology"),
+        secure:          connection.extendedProperty("secure", "changeSecurity"),
+    },
+    mounted() {
+        connection.changeTopology(isTrue(this.$route.query.cluster));
+    },
+}
+</script>
+

--- a/docs/.vuepress/components/client/NodeDetails.vue
+++ b/docs/.vuepress/components/client/NodeDetails.vue
@@ -11,7 +11,7 @@
                   :rules="[ { validator: validateAddress, required: true, trigger: 'blur'} ]"
           >
             <el-input
-                    placeholder="Server address"
+                    :placeholder="placeholder ? placeholder : 'Server address'"
                     v-model="node.address"
                     style="width: 100%;"
             />
@@ -43,7 +43,8 @@ export default {
     name:    "NodeDetails",
     props:   {
         node: Object,
-        single: Boolean
+        single: Boolean,
+        placeholder: String
     },
     methods: {
         validateAddress(rule, value, callback) {

--- a/docs/.vuepress/components/client/NodeUrl.vue
+++ b/docs/.vuepress/components/client/NodeUrl.vue
@@ -1,0 +1,73 @@
+<template>
+  <ClientOnly>
+    <el-form
+            label-width="240px"
+    >
+      <NodeDetails :node="node" :single="true" placeholder="localhost"/>
+
+      <el-form-item>
+        <el-button icon="el-icon-magic-stick" type="primary" :disabled="disableFetch" @click="fetchConfig">
+          Fetch configuration
+        </el-button>&nbsp;&nbsp;&nbsp;<span v-show="error" style="color: red">{{error}}</span>
+      </el-form-item>
+
+    </el-form>
+  </ClientOnly>
+</template>
+
+<script>
+import connection from "../../store/client/connection";
+import NodeDetails from "./NodeDetails";
+import {getClusterConfig} from "../../lib/gossip";
+import ClientNode from "../../store/client/clientNode";
+import {SeedGossip} from "../../store/shared/gossipTypes";
+
+export default {
+    name:       "NodeUrl",
+    components: {NodeDetails},
+    data() {
+        return {
+            node:  new ClientNode(0),
+            error: undefined
+        }
+    },
+    computed:   {
+        disableFetch() {
+            return this.node.address === "" || this.node.port <= 0;
+        },
+    },
+    watch: {
+        "node.address"() {
+            this.error = "";
+        }
+    },
+    methods:    {
+        async fetchConfig() {
+            const es = await getClusterConfig(this.node.address, this.node.port);
+            if (!es.gossip && !es.info) {
+                this.error = "Unable to reach the specified node";
+                return;
+            }
+
+            connection.changeHosting(false);
+            if (!es.gossip) {
+                connection.changeTopology(false);
+                connection.changeSecurity(es.info.authentication.type !== "insecure");
+                connection.nodes[0].address = this.node.address;
+                connection.nodes[0].port = this.node.port;
+            } else {
+                connection.changeTopology(true);
+                connection.setNodesCount(es.gossip.members.length);
+                connection.gossip.setMethod(SeedGossip);
+                connection.changeSecurity(es.info.authentication.type !== "insecure");
+                for (let i = 0; i < es.gossip.members.length; i++) {
+                    connection.nodes[i].address = es.gossip.members[i].httpEndPointIp;
+                    connection.nodes[i].port = es.gossip.members[i].httpEndPointPort;
+                }
+            }
+
+            this.$emit("proceed");
+        }
+    }
+}
+</script>

--- a/docs/.vuepress/lib/gossip.js
+++ b/docs/.vuepress/lib/gossip.js
@@ -1,0 +1,29 @@
+import * as axios from "axios";
+
+async function get(url, timeout) {
+    //http://bu6lsm2rh41uf5akmiog-2.mesdb.eventstore.cloud:2113/
+
+    try {
+        const response = await axios.default.get(url,
+            {
+                timeout: timeout, withCredentials: false, headers: {"Accept": "application/json"}
+            }
+        );
+        return response.data;
+    } catch (e) {
+        return undefined;
+    }
+}
+
+async function getBoth(address, port, path, timeout) {
+    const base = `${address}:${port}/${path}`;
+    const response = await get(`https://${base}`, timeout);
+    return response ? response : await get(`http://${base}`, timeout);
+}
+
+export async function getClusterConfig(address, port) {
+    const info   = await getBoth(address, port, "info", 500);
+    const gossip = await getBoth(address, port, "gossip", 500);
+
+    return {info, gossip};
+}

--- a/docs/.vuepress/lib/networks.js
+++ b/docs/.vuepress/lib/networks.js
@@ -2,7 +2,7 @@ import * as axios from "axios";
 
 export function isValidDns(domain) {
     const re = /^((?:(?:(?:\w[.\-+]?)*)\w)+)((?:(?:(?:\w[.\-+]?){0,62})\w)+)\.(\w{2,6})$/;
-    return !domain || domain.match(re);
+    return !domain || domain === "localhost" || domain.match(re);
 }
 
 export function isValidIpAddress(ipAddress) {

--- a/docs/.vuepress/store/configurator/platform.js
+++ b/docs/.vuepress/store/configurator/platform.js
@@ -17,10 +17,12 @@ export default new Vue({
             this.platform = platform;
             EventBus.$emit(PlatformChanged, platform);
         },
+        ...properties
+    },
+    computed: {
         isLinux() {
             return this.platform === "linux";
-        },
-        ...properties
+        }
     },
 
     created() {

--- a/docs/clients/grpc/getting-started/README.md
+++ b/docs/clients/grpc/getting-started/README.md
@@ -4,6 +4,12 @@ Get started by connecting your application to EventStoreDB. Complete the form be
 
 ## Connection details
 
+This page can help you to generate the connection string for a single-node or cluster deployment of EventStoreDB. You can use one of the following methods:
+
+- Use the [Event Store Cloud](https://eventstore.com/cloud) cluster ID.
+- Use the address of any node of a self-hosted cluster or single-node deployment. You need to have access to the node for the discovery feature to work.
+- Specify the deployment details manually.
+
 <Connection></Connection>
 
 ### Next step


### PR DESCRIPTION
The URL `/clients/grpc/getting-started/` now contains the auto-discovery feature to generate the connection string for:
- Cloud cluster using the cluster id
- Accessible node HTTP(S) endpoint
- Manual configuration

Autodiscovery is able to find if it's secure or insecure, single node or cluster, how many nodes the cluster has and populate the gossip seed using the gossip data.

One could also call `/clients/grpc/getting-started/?clusterId=bu6lsm2rh41uf5akmiog` (for example) where `bu6lsm2rh41uf5akmiog` is the cluster id and get ti all configured.