### PR TITLE
Update MergeIndexes request to be POST not DELETE

### DIFF
--- a/docs/server/5.0.8/http-api/api/README.md
+++ b/docs/server/5.0.8/http-api/api/README.md
@@ -1941,11 +1941,11 @@ basicAuth
 
 ``` shell
 # You can also use wget
-curl -X DELETE https://eventstore.com/admin/mergeindexes
+curl -X POST -d{} https://eventstore.com/admin/mergeindexes
 
 ```
 
- `DELETE /admin/mergeindexes`
+ `POST /admin/mergeindexes`
 *Merge indexes*
 
 Manually merge indexes after a scavenge operation


### PR DESCRIPTION
The correct usage is to send an empty post to the endpoint.