### PR TITLE
Updated information for .NET 5 gRPC client installation

### DIFF
--- a/docs/.vuepress/modules/grpcClient/components/ConnectionString.vue
+++ b/docs/.vuepress/modules/grpcClient/components/ConnectionString.vue
@@ -10,7 +10,7 @@
         >
           <el-col :span="20">
             <el-input
-                    placeholder="Fill out the form above or enter manually"
+                    placeholder="Fill out the form on the connection details page or enter manually"
                     v-model="connectionString"
             />
           </el-col>

--- a/docs/clients/grpc/getting-started/connecting.md
+++ b/docs/clients/grpc/getting-started/connecting.md
@@ -9,7 +9,9 @@ Install the client SDK package to your project.
 
 ```
 $ dotnet add package EventStore.Client.Grpc.Streams --version 20.6.1
+$ dotnet add package Grpc.Net.Client --version 2.32.0
 ```
+<!-- TODO: when https://github.com/EventStore/EventStore/issues/2707 is resolved and new version with the fix is released - remove the manual Grpc.Net.Client installation -->
 </xode-block>
 <xode-block title="NodeJS" code="connectionString">
 


### PR DESCRIPTION
Updated information for .NET 5 gRPC client installation. It's needed to manually add the reference to Grpc.Net.Client to have a proper fix for the https://github.com/dotnet/core/issues/5265. 

When https://github.com/EventStore/EventStore/issues/2707 is resolved and the new version with the fix is released - remove the manual Grpc.Net.Client installation.

Fixed also placeholder in the connection string input.