### PR TITLE
Added Java gRPC client samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Documentation is written using [VuePress](https://vuepress.vuejs.org/).
 2. Run `yarn install`
 3. Run `yarn docs:dev`
 
+### Adding new programming language snippets
+
+To add new language snippet it's needed to add import of [Prism.JS](https://prismjs.com/) plugin to [VuePress plugins config](docs/.vuepress/enhanceApp.js), e.g.:
+
+```javascript
+import "prismjs/components/prism-java";
+```
+
 ### Troubleshooting
 
 #### Windows

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -6,6 +6,7 @@ import "prismjs/plugins/autolinker/prism-autolinker.min";
 import "prismjs/plugins/autolinker/prism-autolinker.css";
 import Prism from "vue-prism-component";
 import "prismjs/components/prism-csharp";
+import "prismjs/components/prism-java";
 import "prismjs/components/prism-yaml";
 import "prismjs/components/prism-bash";
 import * as gtm from "./gtm/inject";

--- a/docs/.vuepress/theme/components/XodeBlock.vue
+++ b/docs/.vuepress/theme/components/XodeBlock.vue
@@ -34,7 +34,7 @@ export default {
                 const newNode = {...x};
                 try {
                     if (typeof x.text == "string" && x.text.includes(find)) {
-                        newNode.text = x.text.replaceAll(find, this.content);
+                        newNode.text = x.text.replace(find, this.content);
                     }
                 } catch {
                 }

--- a/docs/clients/grpc/appending-events/README.md
+++ b/docs/clients/grpc/appending-events/README.md
@@ -15,6 +15,10 @@ The simplest way to write an event to EventStoreDB is to create an `EventData` o
 
 <<< @/samples/grpc/nodejs/samples/appending-events/index.js#append-to-stream
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/appending_events/AppendingEvents.java#append-to-stream
+</xode-block>
 </xode-group>
 
 As you can see `AppendToStream` method allows takes a collection of `EventData`, which makes possible saving more than one event in a single batch.
@@ -43,6 +47,10 @@ For example:
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/appending-events/index.js#append-duplicate-event
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/appending_events/AppendingEvents.java#append-duplicate-event
 </xode-block>
 </xode-group>
 
@@ -83,6 +91,10 @@ For example if we try and write the same record twice expecting both times that 
 
 <<< @/samples/grpc/nodejs/samples/appending-events/index.js#append-with-no-stream
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/appending_events/AppendingEvents.java#append-with-no-stream
+</xode-block>
 </xode-group>
 
 There are three available stream states: 
@@ -101,6 +113,10 @@ This check can be used to implement optimistic concurrency. When you retrieve a 
 
 <<< @/samples/grpc/nodejs/samples/appending-events/index.js#append-with-concurrency-check
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/appending_events/AppendingEvents.java#append-with-concurrency-check
+</xode-block>
 </xode-group>
 
 <!-- ## Options
@@ -117,5 +133,9 @@ You can provide user credentials to be used to append the data as follows. This 
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/appending-events/index.js#overriding-user-credentials
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/appending_events/AppendingEvents.java#overriding-user-credentials
 </xode-block>
 </xode-group>

--- a/docs/clients/grpc/appending-events/README.md
+++ b/docs/clients/grpc/appending-events/README.md
@@ -56,7 +56,7 @@ For example:
 
 will result in only a single event being written
 
-![Duplicate Event](/docs/clients/grpc/appending-events/images/duplicate-event.png)
+![Duplicate Event](./images/dupicate-event.png)
 
 ### type
 

--- a/docs/clients/grpc/appending-events/README.md
+++ b/docs/clients/grpc/appending-events/README.md
@@ -17,7 +17,7 @@ The simplest way to write an event to EventStoreDB is to create an `EventData` o
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/appending_events/AppendingEvents.java#append-to-stream
+<<< @/docs/clients/java/generated/0.6/samples/appending_events/AppendingEvents.java#append-to-stream
 </xode-block>
 </xode-group>
 
@@ -50,7 +50,7 @@ For example:
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/appending_events/AppendingEvents.java#append-duplicate-event
+<<< @/docs/clients/java/generated/0.6/samples/appending_events/AppendingEvents.java#append-duplicate-event
 </xode-block>
 </xode-group>
 
@@ -93,7 +93,7 @@ For example if we try and write the same record twice expecting both times that 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/appending_events/AppendingEvents.java#append-with-no-stream
+<<< @/docs/clients/java/generated/0.6/samples/appending_events/AppendingEvents.java#append-with-no-stream
 </xode-block>
 </xode-group>
 
@@ -115,7 +115,7 @@ This check can be used to implement optimistic concurrency. When you retrieve a 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/appending_events/AppendingEvents.java#append-with-concurrency-check
+<<< @/docs/clients/java/generated/0.6/samples/appending_events/AppendingEvents.java#append-with-concurrency-check
 </xode-block>
 </xode-group>
 
@@ -136,6 +136,6 @@ You can provide user credentials to be used to append the data as follows. This 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/appending_events/AppendingEvents.java#overriding-user-credentials
+<<< @/docs/clients/java/generated/0.6/samples/appending_events/AppendingEvents.java#overriding-user-credentials
 </xode-block>
 </xode-group>

--- a/docs/clients/grpc/getting-started/connecting.md
+++ b/docs/clients/grpc/getting-started/connecting.md
@@ -100,7 +100,7 @@ The code snippet below creates an event object instance, serializes it and puts 
 
 <<< @/samples/grpc/nodejs/samples/getStarted.js#createEvent
 </xode-block>
-<xode-block title="Java" code="connectionString">
+<xode-block title="Java">
 
 <<< @/docs/clients/java/generated/0.5/samples/quick_start/QuickStart.java#createEvent
 </xode-block>
@@ -121,7 +121,7 @@ In the snippet below, we append the event to the stream `some-stream`.
 
 <<< @/samples/grpc/nodejs/samples/getStarted.js#appendEvents
 </xode-block>
-<xode-block title="Java" code="connectionString">
+<xode-block title="Java">
 
 <<< @/docs/clients/java/generated/0.5/samples/quick_start/QuickStart.java#appendEvents
 </xode-block>
@@ -142,7 +142,7 @@ Finally, we can read events back from the `some-stream` stream.
 
 <<< @/samples/grpc/nodejs/samples/getStarted.js#readStream
 </xode-block>
-<xode-block title="Java" code="connectionString">
+<xode-block title="Java">
 
 <<< @/docs/clients/java/generated/0.5/samples/quick_start/QuickStart.java#readStream
 </xode-block>

--- a/docs/clients/grpc/getting-started/connecting.md
+++ b/docs/clients/grpc/getting-started/connecting.md
@@ -37,7 +37,7 @@ $ npm install --save @eventstore/db-client
 implementation 'com.eventstore:db-client-java:0.5'
 
 # SBT
-libraryDependencies += "com.eventstore" % "db-client-java" % "0.5"
+libraryDependencies += "com.eventstore" % "db-client-java" % "0.6"
 ```
 </xode-block>
 </xode-group>
@@ -73,7 +73,7 @@ First thing first, we need a client.
 </xode-block>
 <xode-block title="Java" code="connectionString">
 
-<<< @/docs/clients/java/generated/0.5/samples/quick_start/QuickStart.java#createClient
+<<< @/docs/clients/java/generated/0.6/samples/quick_start/QuickStart.java#createClient
 </xode-block>
 </xode-group>
 
@@ -102,7 +102,7 @@ The code snippet below creates an event object instance, serializes it and puts 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/quick_start/QuickStart.java#createEvent
+<<< @/docs/clients/java/generated/0.6/samples/quick_start/QuickStart.java#createEvent
 </xode-block>
 </xode-group>
 
@@ -123,7 +123,7 @@ In the snippet below, we append the event to the stream `some-stream`.
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/quick_start/QuickStart.java#appendEvents
+<<< @/docs/clients/java/generated/0.6/samples/quick_start/QuickStart.java#appendEvents
 </xode-block>
 </xode-group>
 
@@ -144,7 +144,7 @@ Finally, we can read events back from the `some-stream` stream.
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/quick_start/QuickStart.java#readStream
+<<< @/docs/clients/java/generated/0.6/samples/quick_start/QuickStart.java#readStream
 </xode-block>
 </xode-group>
 

--- a/docs/clients/grpc/getting-started/connecting.md
+++ b/docs/clients/grpc/getting-started/connecting.md
@@ -13,7 +13,7 @@ $ dotnet add package Grpc.Net.Client --version 2.32.0
 ```
 <!-- TODO: when https://github.com/EventStore/EventStore/issues/2707 is resolved and new version with the fix is released - remove the manual Grpc.Net.Client installation -->
 </xode-block>
-<xode-block title="NodeJS" code="connectionString">
+<xode-block title="NodeJS">
 
 ```
 # Yarn
@@ -21,6 +21,23 @@ $ yarn add @eventstore/db-client
 
 # NPM
 $ npm install --save @eventstore/db-client
+```
+</xode-block>
+<xode-block title="Java">
+
+```
+# Maven
+<dependency>
+  <groupId>com.eventstore</groupId>
+  <artifactId>db-client-java</artifactId>
+  <version>0.5</version>
+</dependency>
+
+# Gradle
+implementation 'com.eventstore:db-client-java:0.5'
+
+# SBT
+libraryDependencies += "com.eventstore" % "db-client-java" % "0.5"
 ```
 </xode-block>
 </xode-group>
@@ -56,7 +73,7 @@ First thing first, we need a client.
 </xode-block>
 <xode-block title="Java" code="connectionString">
 
-<<< @/docs/clients/java/generated/0.5/samples/GetStarted.java#createClient
+<<< @/docs/clients/java/generated/0.5/samples/quick_start/QuickStart.java#createClient
 </xode-block>
 </xode-group>
 
@@ -85,7 +102,7 @@ The code snippet below creates an event object instance, serializes it and puts 
 </xode-block>
 <xode-block title="Java" code="connectionString">
 
-<<< @/docs/clients/java/generated/0.5/samples/GetStarted.java#createEvent
+<<< @/docs/clients/java/generated/0.5/samples/quick_start/QuickStart.java#createEvent
 </xode-block>
 </xode-group>
 
@@ -106,7 +123,7 @@ In the snippet below, we append the event to the stream `some-stream`.
 </xode-block>
 <xode-block title="Java" code="connectionString">
 
-<<< @/docs/clients/java/generated/0.5/samples/GetStarted.java#appendEvents
+<<< @/docs/clients/java/generated/0.5/samples/quick_start/QuickStart.java#appendEvents
 </xode-block>
 </xode-group>
 
@@ -127,7 +144,7 @@ Finally, we can read events back from the `some-stream` stream.
 </xode-block>
 <xode-block title="Java" code="connectionString">
 
-<<< @/docs/clients/java/generated/0.5/samples/GetStarted.java#readStream
+<<< @/docs/clients/java/generated/0.5/samples/quick_start/QuickStart.java#readStream
 </xode-block>
 </xode-group>
 

--- a/docs/clients/grpc/getting-started/connecting.md
+++ b/docs/clients/grpc/getting-started/connecting.md
@@ -54,6 +54,10 @@ First thing first, we need a client.
 
 <<< @/samples/grpc/nodejs/samples/getStarted.js#createClient
 </xode-block>
+<xode-block title="Java" code="connectionString">
+
+<<< @/docs/clients/java/generated/0.5/samples/GetStarted.java#createClient
+</xode-block>
 </xode-group>
 
 The client instance can be used as a singleton across the whole application. It doesn't need to open or close the connection.
@@ -79,6 +83,10 @@ The code snippet below creates an event object instance, serializes it and puts 
 
 <<< @/samples/grpc/nodejs/samples/getStarted.js#createEvent
 </xode-block>
+<xode-block title="Java" code="connectionString">
+
+<<< @/docs/clients/java/generated/0.5/samples/GetStarted.java#createEvent
+</xode-block>
 </xode-group>
 
 ## Writing events
@@ -96,6 +104,10 @@ In the snippet below, we append the event to the stream `some-stream`.
 
 <<< @/samples/grpc/nodejs/samples/getStarted.js#appendEvents
 </xode-block>
+<xode-block title="Java" code="connectionString">
+
+<<< @/docs/clients/java/generated/0.5/samples/GetStarted.java#appendEvents
+</xode-block>
 </xode-group>
 
 Here we are writing events without checking if the stream exists or if the stream version matches the expected event version. See more advanced scenarios in [writing events documentation](../appending-events/README.md).
@@ -112,6 +124,10 @@ Finally, we can read events back from the `some-stream` stream.
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/getStarted.js#readStream
+</xode-block>
+<xode-block title="Java" code="connectionString">
+
+<<< @/docs/clients/java/generated/0.5/samples/GetStarted.java#readStream
 </xode-block>
 </xode-group>
 

--- a/docs/clients/grpc/reading-events/reading-from-a-stream.md
+++ b/docs/clients/grpc/reading-events/reading-from-a-stream.md
@@ -15,6 +15,10 @@ The simplest way to read a stream forwards is to supply a stream name, direction
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#read-from-stream
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-stream
+</xode-block>
 </xode-group>
 
 This will return an enumerable that can be iterated on:
@@ -27,6 +31,10 @@ This will return an enumerable that can be iterated on:
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#iterate-stream
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#iterate-stream
 </xode-block>
 </xode-group>
  
@@ -52,9 +60,13 @@ The credentials used to read the data can be supplied. to be used by the subscri
 
 <<< @/samples/grpc/dotnet/GrpcDocs/Consumer.cs#overriding-user-credentials
 </xode-block>
-<xode-block title="NodeJS">
+<xode-block title="NodeJS"> 
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#overriding-user-credentials
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#overriding-user-credentials
 </xode-block>
 </xode-group>
 
@@ -71,6 +83,10 @@ As well as providing a `StreamPosition` you can also provide a specific stream r
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#read-from-stream-position
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-stream-position
+</xode-block>
 </xode-group>
 
 ## Reading backwards
@@ -85,6 +101,10 @@ As well as being able to read a stream forwards you can also go backwards. When 
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#reading-backwards 
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#reading-backwards
 </xode-block>
 </xode-group>
 
@@ -105,5 +125,9 @@ It is important to check the value of this field before attempting to iterate an
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#checking-for-stream-presence
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#checking-for-stream-presence
 </xode-block>
 </xode-group>

--- a/docs/clients/grpc/reading-events/reading-from-a-stream.md
+++ b/docs/clients/grpc/reading-events/reading-from-a-stream.md
@@ -17,7 +17,7 @@ The simplest way to read a stream forwards is to supply a stream name, direction
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-stream
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#read-from-stream
 </xode-block>
 </xode-group>
 
@@ -34,7 +34,7 @@ This will return an enumerable that can be iterated on:
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#iterate-stream
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#iterate-stream
 </xode-block>
 </xode-group>
  
@@ -66,7 +66,7 @@ The credentials used to read the data can be supplied. to be used by the subscri
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#overriding-user-credentials
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#overriding-user-credentials
 </xode-block>
 </xode-group>
 
@@ -85,7 +85,7 @@ As well as providing a `StreamPosition` you can also provide a specific stream r
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-stream-position
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#read-from-stream-position
 </xode-block>
 </xode-group>
 
@@ -104,7 +104,7 @@ As well as being able to read a stream forwards you can also go backwards. When 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#reading-backwards
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#reading-backwards
 </xode-block>
 </xode-group>
 
@@ -128,6 +128,6 @@ It is important to check the value of this field before attempting to iterate an
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#checking-for-stream-presence
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#checking-for-stream-presence
 </xode-block>
 </xode-group>

--- a/docs/clients/grpc/reading-events/reading-from-the-all-stream.md
+++ b/docs/clients/grpc/reading-events/reading-from-the-all-stream.md
@@ -2,6 +2,7 @@
 
 Reading from the all stream is similar to reading from an individual stream but with some small differences. Primarily the need to provide an admin user account credentials and that you need to to provide a transaction log position instead of a stream revision.
 
+
 ## Reading forwards
 
 The simplest way to read the `$all` stream forwards is to supply a direction and transaction log position to start from. This can either be a *stream position* `Start` or a *big int* (unsigned 64 bit integer):
@@ -15,6 +16,10 @@ The simplest way to read the `$all` stream forwards is to supply a direction and
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#read-from-all-stream
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-all-stream
+</xode-block>
 </xode-group>
 
 This will return an AsyncEnumerable that can be iterated on:
@@ -27,6 +32,10 @@ This will return an AsyncEnumerable that can be iterated on:
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#read-from-all-stream-iterate
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-all-stream-iterate
 </xode-block>
 </xode-group>
 
@@ -50,6 +59,10 @@ When using projections to create new events you can set whether the generated ev
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#read-from-all-stream-resolving-link-Tos
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-all-stream-resolving-link-Tos
+</xode-block>
 </xode-group>
 
 ### configureOperationOptions
@@ -68,6 +81,10 @@ The credentials used to read the data can be supplied. to be used by the subscri
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#read-all-overriding-user-credentials
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-all-overriding-user-credentials
+</xode-block>
 </xode-group>
  
 ## Reading backwards
@@ -82,6 +99,10 @@ As well as being able to read a stream forwards you can also go backwards. When 
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#read-from-all-stream-backwards 
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-all-stream-backwards 
 </xode-block>
 </xode-group>
 
@@ -104,7 +125,8 @@ All system events begin with `$` or `$$` and can be easily ignored by checking t
 
 <<< @/samples/grpc/nodejs/samples/reading-events/index.js#ignore-system-events 
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#ignore-system-events
+</xode-block>
 </xode-group>
- 
-<!--## Understanding the $all stream position
-TODO--!>

--- a/docs/clients/grpc/reading-events/reading-from-the-all-stream.md
+++ b/docs/clients/grpc/reading-events/reading-from-the-all-stream.md
@@ -18,7 +18,7 @@ The simplest way to read the `$all` stream forwards is to supply a direction and
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-all-stream
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#read-from-all-stream
 </xode-block>
 </xode-group>
 
@@ -35,7 +35,7 @@ This will return an AsyncEnumerable that can be iterated on:
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-all-stream-iterate
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#read-from-all-stream-iterate
 </xode-block>
 </xode-group>
 
@@ -61,7 +61,7 @@ When using projections to create new events you can set whether the generated ev
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-all-stream-resolving-link-Tos
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#read-from-all-stream-resolving-link-Tos
 </xode-block>
 </xode-group>
 
@@ -83,7 +83,7 @@ The credentials used to read the data can be supplied. to be used by the subscri
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-all-overriding-user-credentials
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#read-all-overriding-user-credentials
 </xode-block>
 </xode-group>
  
@@ -102,7 +102,7 @@ As well as being able to read a stream forwards you can also go backwards. When 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#read-from-all-stream-backwards 
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#read-from-all-stream-backwards 
 </xode-block>
 </xode-group>
 
@@ -127,6 +127,6 @@ All system events begin with `$` or `$$` and can be easily ignored by checking t
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/reading_events/ReadingEvents.java#ignore-system-events
+<<< @/docs/clients/java/generated/0.6/samples/reading_events/ReadingEvents.java#ignore-system-events
 </xode-block>
 </xode-group>

--- a/docs/clients/grpc/subscribing-to-streams/README.md
+++ b/docs/clients/grpc/subscribing-to-streams/README.md
@@ -23,6 +23,10 @@ The simplest stream subscription looks like the following :
 
 <<< @/samples/grpc/nodejs/samples/subscribing-to-streams/index.js#subscribe-to-stream
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream
+</xode-block>
 </xode-group>
 
 The provided handler will be called for every event in the stream.
@@ -39,6 +43,10 @@ Subscribing to `$all` is much the same as subscribing to a single stream. The ha
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/subscribing-to-streams/index.js#subscribe-to-all
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all
 </xode-block>
 </xode-group>
 
@@ -70,6 +78,10 @@ The following subscribes to the stream "some-stream" at position 20, this means 
 
 <<< @/samples/grpc/nodejs/samples/subscribing-to-streams/index.js#subscribe-to-stream-from-position
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-from-position
+</xode-block>
 </xode-group>
 
 ### Subscribing to $all
@@ -89,6 +101,10 @@ Please note that this position will need to be a legitimate position in `$all`.
 
 <<< @/samples/grpc/nodejs/samples/subscribing-to-streams/index.js#subscribe-to-all-from-position
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-from-position
+</xode-block>
 </xode-group>
 
 ## Subscribing to a stream for live updates
@@ -104,6 +120,10 @@ You can subscribe to a stream to get live updates by subscribing to the end of t
 
 <<< @/samples/grpc/nodejs/samples/subscribing-to-streams/index.js#subscribe-to-stream-live
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-live
+</xode-block>
 </xode-group>
 
 And the same works with `$all` :
@@ -116,6 +136,10 @@ And the same works with `$all` :
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/subscribing-to-streams/index.js#subscribe-to-all-live
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-live
 </xode-block>
 </xode-group>
 
@@ -139,6 +163,10 @@ When reading a stream you can specify whether to resolve link tos or not. By def
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/subscribing-to-streams/index.js#subscribe-to-stream-resolving-linktos
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-resolving-linktos
 </xode-block>
 </xode-group>
 
@@ -171,6 +199,10 @@ You can start from where you left off by keeping a record of the last processed 
 // TODO
 ```
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-subscription-dropped
+</xode-block>
 </xode-group>
 
 When subscribed to `$all` you want to keep the position of the event in the `$all` stream :
@@ -185,6 +217,10 @@ When subscribed to `$all` you want to keep the position of the event in the `$al
 ```
 // TODO
 ```
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-subscription-dropped
 </xode-block>
 </xode-group>
 
@@ -202,6 +238,10 @@ A simple stream prefix filter looks like this :
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/subscribing-to-streams/index.js#stream-prefix-filtered-subscription
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#stream-prefix-filtered-subscription
 </xode-block>
 </xode-group>
 
@@ -221,6 +261,10 @@ You can provide user credentials to be used by the subscription as follows. This
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/subscribing-to-streams/index.js#overriding-user-credentials
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#overriding-user-credentials
 </xode-block>
 </xode-group>
 

--- a/docs/clients/grpc/subscribing-to-streams/README.md
+++ b/docs/clients/grpc/subscribing-to-streams/README.md
@@ -25,7 +25,7 @@ The simplest stream subscription looks like the following :
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream
+<<< @/docs/clients/java/generated/0.6/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream
 </xode-block>
 </xode-group>
 
@@ -46,7 +46,7 @@ Subscribing to `$all` is much the same as subscribing to a single stream. The ha
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all
+<<< @/docs/clients/java/generated/0.6/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all
 </xode-block>
 </xode-group>
 
@@ -80,7 +80,7 @@ The following subscribes to the stream "some-stream" at position 20, this means 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-from-position
+<<< @/docs/clients/java/generated/0.6/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-from-position
 </xode-block>
 </xode-group>
 
@@ -103,7 +103,7 @@ Please note that this position will need to be a legitimate position in `$all`.
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-from-position
+<<< @/docs/clients/java/generated/0.6/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-from-position
 </xode-block>
 </xode-group>
 
@@ -122,7 +122,7 @@ You can subscribe to a stream to get live updates by subscribing to the end of t
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-live
+<<< @/docs/clients/java/generated/0.6/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-live
 </xode-block>
 </xode-group>
 
@@ -139,7 +139,7 @@ And the same works with `$all` :
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-live
+<<< @/docs/clients/java/generated/0.6/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-live
 </xode-block>
 </xode-group>
 
@@ -166,7 +166,7 @@ When reading a stream you can specify whether to resolve link tos or not. By def
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-resolving-linktos
+<<< @/docs/clients/java/generated/0.6/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-resolving-linktos
 </xode-block>
 </xode-group>
 
@@ -201,7 +201,7 @@ You can start from where you left off by keeping a record of the last processed 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-subscription-dropped
+<<< @/docs/clients/java/generated/0.6/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-subscription-dropped
 </xode-block>
 </xode-group>
 
@@ -220,7 +220,7 @@ When subscribed to `$all` you want to keep the position of the event in the `$al
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-subscription-dropped
+<<< @/docs/clients/java/generated/0.6/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-subscription-dropped
 </xode-block>
 </xode-group>
 
@@ -241,7 +241,7 @@ A simple stream prefix filter looks like this :
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#stream-prefix-filtered-subscription
+<<< @/docs/clients/java/generated/0.6/samples/subscribing_to_stream/SubscribingToStream.java#stream-prefix-filtered-subscription
 </xode-block>
 </xode-group>
 
@@ -264,7 +264,7 @@ You can provide user credentials to be used by the subscription as follows. This
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/subscribing_to_stream/SubscribingToStream.java#overriding-user-credentials
+<<< @/docs/clients/java/generated/0.6/samples/subscribing_to_stream/SubscribingToStream.java#overriding-user-credentials
 </xode-block>
 </xode-group>
 

--- a/docs/clients/grpc/subscribing-to-streams/filtering.md
+++ b/docs/clients/grpc/subscribing-to-streams/filtering.md
@@ -23,7 +23,7 @@ There are a number of events in EventStoreDB called system events. These are pre
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#exclude-system
+<<< @/docs/clients/java/generated/0.6/samples/server_side_filtering/ServerSideFiltering.java#exclude-system
 </xode-block>
 </xode-group>
 
@@ -50,7 +50,7 @@ If you want to filter by prefix pass in a `SubscriptionFilterOptions` to the sub
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#event-type-prefix
+<<< @/docs/clients/java/generated/0.6/samples/server_side_filtering/ServerSideFiltering.java#event-type-prefix
 </xode-block>
 </xode-group>
 
@@ -71,7 +71,7 @@ If you want to subscribe to multiple event types then it might be better to prov
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#event-type-regex
+<<< @/docs/clients/java/generated/0.6/samples/server_side_filtering/ServerSideFiltering.java#event-type-regex
 </xode-block>
 </xode-group>
 
@@ -96,7 +96,7 @@ If you want to filter by prefix pass in a `SubscriptionFilterOptions` to the sub
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#stream-prefix
+<<< @/docs/clients/java/generated/0.6/samples/server_side_filtering/ServerSideFiltering.java#stream-prefix
 </xode-block>
 </xode-group>
 
@@ -117,7 +117,7 @@ If you want to subscribe to multiple streams then it might be better to provide 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#stream-regex
+<<< @/docs/clients/java/generated/0.6/samples/server_side_filtering/ServerSideFiltering.java#stream-regex
 </xode-block>
 </xode-group>
 
@@ -144,7 +144,7 @@ To make use of it set up `checkpointReached` on the `SubscriptionFilterOptions` 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#checkpoint
+<<< @/docs/clients/java/generated/0.6/samples/server_side_filtering/ServerSideFiltering.java#checkpoint
 </xode-block>
 </xode-group>
 
@@ -161,7 +161,7 @@ To make use of it set up `checkpointReached` on the `SubscriptionFilterOptions` 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#checkpoint-with-interval
+<<< @/docs/clients/java/generated/0.6/samples/server_side_filtering/ServerSideFiltering.java#checkpoint-with-interval
 </xode-block>
 </xode-group>
 

--- a/docs/clients/grpc/subscribing-to-streams/filtering.md
+++ b/docs/clients/grpc/subscribing-to-streams/filtering.md
@@ -21,6 +21,10 @@ There are a number of events in EventStoreDB called system events. These are pre
 
 <<< @/samples/grpc/nodejs/samples/server-side-filtering/index.js#exclude-system
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#exclude-system
+</xode-block>
 </xode-group>
 
 ::: tip
@@ -44,6 +48,10 @@ If you want to filter by prefix pass in a `SubscriptionFilterOptions` to the sub
 
 <<< @/samples/grpc/nodejs/samples/server-side-filtering/index.js#event-type-prefix
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#event-type-prefix
+</xode-block>
 </xode-group>
 
 This will only subscribe to events with a type that begin with `customer-`.
@@ -60,6 +68,10 @@ If you want to subscribe to multiple event types then it might be better to prov
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/server-side-filtering/index.js#event-type-regex
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#event-type-regex
 </xode-block>
 </xode-group>
 
@@ -82,6 +94,10 @@ If you want to filter by prefix pass in a `SubscriptionFilterOptions` to the sub
 
 <<< @/samples/grpc/nodejs/samples/server-side-filtering/index.js#stream-prefix
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#stream-prefix
+</xode-block>
 </xode-group>
 
 This will only subscribe to streams with a name that begin with `user-`.
@@ -98,6 +114,10 @@ If you want to subscribe to multiple streams then it might be better to provide 
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/server-side-filtering/index.js#stream-regex
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#stream-regex
 </xode-block>
 </xode-group>
 
@@ -122,6 +142,10 @@ To make use of it set up `checkpointReached` on the `SubscriptionFilterOptions` 
 // TODO
 ```
 </xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#checkpoint
+</xode-block>
 </xode-group>
 
  This will be called every `n` number of events. If you want to be specific about the number of events threshold you can also pass that as a parameter.
@@ -134,6 +158,10 @@ To make use of it set up `checkpointReached` on the `SubscriptionFilterOptions` 
 <xode-block title="NodeJS">
 
 <<< @/samples/grpc/nodejs/samples/server-side-filtering/index.js#checkpoint-with-interval
+</xode-block>
+<xode-block title="Java">
+
+<<< @/docs/clients/java/generated/0.5/samples/server_side_filtering/ServerSideFiltering.java#checkpoint-with-interval
 </xode-block>
 </xode-group>
 

--- a/docs/clients/java/versions.json
+++ b/docs/clients/java/versions.json
@@ -5,9 +5,8 @@
     "basePath": "clients/java",
     "versions": [
       {
-        "version": "0.5 (Java)",
-        "path": "0.5",
-        "startPage": "getting-started/"
+        "version": "0.6 (Java)",
+        "path": "0.6"
       }
     ]
   }

--- a/docs/clients/java/versions.json
+++ b/docs/clients/java/versions.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "java-client",
+    "group": "Java SDK",
+    "basePath": "clients/java",
+    "versions": [
+      {
+        "version": "0.5 (Java)",
+        "path": "0.5",
+        "startPage": "getting-started/"
+      }
+    ]
+  }
+]

--- a/import/import-client-docs.js
+++ b/import/import-client-docs.js
@@ -42,11 +42,11 @@ async function replaceCodePath(mdPath, samplesPath) {
     await sh(replaceCommand);
 }
 
-async function copy(clientRepo, repoLocation, docsLocation, id, tag, innerPath) {
+async function copy(clientRepo, repoLocation, docsLocation, id, tag, relativePath) {
     log.info(`checking out ${tag}...`);
     await clientRepo.checkout(tag);
 
-    const pathElements = [repoLocation, ...(innerPath || ['docs'])];
+    const pathElements = [repoLocation, ...(relativePath || ['docs'])];
 
     if (fs.existsSync(path.join(...pathElements))) {
         log.info('docs exist, copying...');
@@ -97,7 +97,7 @@ async function main() {
             .filter(i => i)
 
         if (deployCurrent) {
-            definition[0].versions.push(await copy(clientRepo, repoLocation, docsLocation, tags.slice(-1)[0], repo.currentBranch, repo.innerPath));
+            definition[0].versions.push(await copy(clientRepo, repoLocation, docsLocation, tags.slice(-1)[0], repo.currentBranch, repo.relativePath));
         }
 
         for (let i = 0; i < tags.length - 1; i++) {

--- a/import/repos.json
+++ b/import/repos.json
@@ -11,7 +11,7 @@
     "group": "Java SDK",
     "basePath": "clients/java",
     "relativePath": ["db-client-java","src","test","java","com","eventstore","dbclient"],
-    "currentBranch": "samples",
+    "currentBranch": "trunk",
     "repo": "https://github.com/EventStore/EventStoreDB-Client-Java.git"
   }
 ]

--- a/import/repos.json
+++ b/import/repos.json
@@ -10,7 +10,7 @@
     "id": "java-client",
     "group": "Java SDK",
     "basePath": "clients/java",
-    "innerPath": ["db-client-java","src","test","java","com","eventstore","dbclient"],
+    "relativePath": ["db-client-java","src","test","java","com","eventstore","dbclient"],
     "currentBranch": "samples",
     "repo": "https://github.com/EventStore/EventStoreDB-Client-Java.git"
   }

--- a/import/repos.json
+++ b/import/repos.json
@@ -5,5 +5,13 @@
     "basePath": "clients/dotnet",
     "currentBranch": "initial-docs",
     "repo": "https://github.com/EventStore/EventStore-Client-Dotnet.git"
+  },
+  {
+    "id": "java-client",
+    "group": "Java SDK",
+    "basePath": "clients/java",
+    "innerPath": ["db-client-java","src","test","java","com","eventstore","dbclient"],
+    "currentBranch": "samples",
+    "repo": "https://github.com/EventStore/EventStoreDB-Client-Java.git"
   }
 ]

--- a/samples/grpc/nodejs/samples/getStarted.js
+++ b/samples/grpc/nodejs/samples/getStarted.js
@@ -8,9 +8,9 @@ import { v4 as uuid } from "uuid";
 
 export default function (router) {
   router.get("/", async function (req, res, next) {
-    // region createClient
+// region createClient
     const client = EventStoreDBClient.connectionString("{connectionString}");
-    // endregion createClient
+// endregion createClient
 
     // region createEvent
     const event = jsonEvent({


### PR DESCRIPTION
- Included Java snippets into gRPC docs. See related PR: https://github.com/EventStore/EventStoreDB-Client-Java/pull/55
- Updated import script to take samples from Java client repo 

See a preview: https://deploy-preview-191--developers-eventstore.netlify.app/clients/grpc/getting-started/. 