### PR TITLE
Added default code language selection to allow preselecting the language from URL

### DIFF
--- a/docs/.vuepress/theme/store/index.js
+++ b/docs/.vuepress/theme/store/index.js
@@ -1,13 +1,18 @@
 import {ChangeLanguage, SetSiteLanguages, SubmitCodeBlock, UpdateConnectionString} from "./mutations";
 import {GetSelectedLanguage, GetSiteLanguages} from "./getters";
-import {setStorageValue} from "../util/localStorage";
+import {setStorageValue, getStorageValue} from "../util/localStorage";
+import {getUrlParamValue} from "../util/url"
 
 const prefix = "eventstore-docs";
 const langStorageName = "codeLanguage";
 
+function getSelectedCodeLanguage() {
+    return getUrlParamValue(langStorageName) || getStorageValue(prefix, langStorageName) || "";
+}
+
 const state = {
     connectionString: "",
-    codeLanguage: "",
+    codeLanguage: getSelectedCodeLanguage(),
     codeBlocks: {}
 };
 

--- a/docs/.vuepress/theme/util/index.js
+++ b/docs/.vuepress/theme/util/index.js
@@ -3,10 +3,6 @@ export const extRE = /\.(md|html)$/
 export const endingSlashRE = /\/$/
 export const outboundRE = /^[a-z]+:/i
 
-export function isUndefined(x) {
-  return typeof x === "undefined";
-}
-
 export function normalize (path) {
   return decodeURI(path)
     .replace(hashRE, '')

--- a/docs/.vuepress/theme/util/localStorage.js
+++ b/docs/.vuepress/theme/util/localStorage.js
@@ -1,18 +1,18 @@
 import {isUndefined} from "./index";
 
 export function setStorageValue(prefix, name, value) {
-    if (isUndefined(localStorage)) {
+    if (typeof localStorage === "undefined") {
         return;
     }
     localStorage[prefix + name] = value;
 }
 
 export function getStorageValue(prefix, name) {
-    if (isUndefined(localStorage)) {
+    if (typeof localStorage === "undefined") {
         return null;
     }
     name = prefix + name;
-    if (isUndefined(localStorage[name])) {
+    if (!localStorage[name]) {
         return null;
     }
     return localStorage[name];

--- a/docs/.vuepress/theme/util/url.js
+++ b/docs/.vuepress/theme/util/url.js
@@ -1,0 +1,7 @@
+export function getUrlParamValue(name) {
+    if (typeof window === "undefined") {
+        return null;
+    }
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get(name);
+}


### PR DESCRIPTION
Added default code language selection to allow preselecting the language from URL by adding query parameter `?codeLanguage={language}`

The order of selection will be:
- URL,
- local storage (so previously selected),
- no selection (so first tab)..

Available languages (casing matters):
- `C#`
- `NodeJS`
- `Java`