### PR TITLE
Update the NodeJS snippets to the latest NodeJS gRPC client API changes

### DIFF
--- a/samples/grpc/nodejs/package.json
+++ b/samples/grpc/nodejs/package.json
@@ -11,7 +11,7 @@
     "prettier:fix": "prettier --write \"**/**/!(*.d).{js,json}\""
   },
   "dependencies": {
-    "@eventstore/db-client": "0.0.0-alpha.12",
+    "@eventstore/db-client": "0.0.0-alpha.17",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
     "eslint": "^7.5.0",

--- a/samples/grpc/nodejs/package.json
+++ b/samples/grpc/nodejs/package.json
@@ -11,7 +11,7 @@
     "prettier:fix": "prettier --write \"**/**/!(*.d).{js,json}\""
   },
   "dependencies": {
-    "@eventstore/db-client": "0.0.0-alpha.17",
+    "@eventstore/db-client": "1.0.0",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
     "eslint": "^7.5.0",

--- a/samples/grpc/nodejs/samples/getStarted.js
+++ b/samples/grpc/nodejs/samples/getStarted.js
@@ -29,9 +29,10 @@ export default function (router) {
     // endregion appendEvents
 
     // region readStream
-    const events = await client.readStream("some-stream", 10, {
+    const events = await client.readStream("some-stream", {
       direction: FORWARDS,
       fromRevision: START,
+      maxCount: 10
     });
     // endregion readStream
 

--- a/samples/grpc/nodejs/samples/reading-events/index.js
+++ b/samples/grpc/nodejs/samples/reading-events/index.js
@@ -4,13 +4,15 @@ import {
   FORWARDS,
   BACKWARDS,
   ErrorType,
+  EventStoreDBClient
 } from "@eventstore/db-client";
 
 export async function readFromStream(client) {
   // region read-from-stream
-  const events = await client.readStream("some-stream", 10, {
+  const events = await client.readStream("some-stream", {
     direction: FORWARDS,
     fromRevision: START,
+    maxCount: 10,
   });
   // endregion read-from-stream
 
@@ -25,9 +27,10 @@ export async function readFromStream(client) {
 
 export async function readFromStreamPosition(client) {
   // region read-from-stream-position
-  const events = await client.readStream("some-stream", 20, {
+  const events = await client.readStream("some-stream", {
     direction: FORWARDS,
     fromRevision: BigInt(10),
+    maxCount: 20,
   });
   // endregion read-from-stream-position
 
@@ -44,9 +47,10 @@ export async function readFromStreamPositionCheck(client) {
   // region checking-for-stream-presence
   let events = [];
   try {
-    events = await client.readStream("some-stream", 20, {
+    events = await client.readStream("some-stream", {
       direction: FORWARDS,
       fromRevision: BigInt(10),
+      maxCount: 20,
     });
   } catch (error) {
     if (error.type == ErrorType.STREAM_NOT_FOUND) return;
@@ -68,10 +72,11 @@ export async function readFromStreamOverridingCredentials(client) {
     username: "admin",
     password: "changeit",
   };
-  const events = await client.readStream("some-stream", 10, {
+  const events = await client.readStream("some-stream", {
     direction: FORWARDS,
     fromRevision: START,
     credentials,
+    maxCount: 10,
   });
   // endregion overriding-user-credentials
 
@@ -80,9 +85,10 @@ export async function readFromStreamOverridingCredentials(client) {
 
 export async function readFromStreamBackwards(client) {
   // region reading-backwards
-  const events = await client.readStream("some-stream", 10, {
+  const events = await client.readStream("some-stream", {
     direction: BACKWARDS,
     fromRevision: END,
+    maxCount: 10,
   });
 
   for (var resolvedEvent of events) {
@@ -95,9 +101,10 @@ export async function readFromStreamBackwards(client) {
 
 export async function readFromAllStream(client) {
   // region read-from-all-stream
-  const events = await client.readAll(10, {
+  const events = await client.readAll({
     direction: FORWARDS,
     fromPosition: START,
+    maxCount: 10,
   });
   // endregion read-from-all-stream
 
@@ -112,9 +119,10 @@ export async function readFromAllStream(client) {
 
 export async function ignoreSystemEvents(client) {
   // region ignore-system-events
-  const events = await client.readAll(10, {
+  const events = await client.readAll({
     direction: FORWARDS,
     fromPosition: START,
+    maxCount: 10,
   });
 
   for (const resolvedEvent of events) {
@@ -130,9 +138,10 @@ export async function ignoreSystemEvents(client) {
 
 export async function readFromAllStreamBackwards(client) {
   // region read-from-all-stream-backwards
-  const events = await client.readAll(10, {
+  const events = await client.readAll({
     direction: BACKWARDS,
     fromPosition: END,
+    maxCount: 10,
   });
   // endregion read-from-all-stream-backwards
 
@@ -151,10 +160,11 @@ export async function readFromAllOverridingCredentials(client) {
     username: "admin",
     password: "changeit",
   };
-  const events = await client.readAll(10, {
+  const events = await client.readAll({
     direction: FORWARDS,
     fromPosition: START,
     credentials,
+    maxCount: 10,
   });
   // endregion read-all-overriding-user-credentials
 
@@ -163,9 +173,10 @@ export async function readFromAllOverridingCredentials(client) {
 
 export async function filterOutSystemEvents(client) {
   // region filter-out-system-events
-  const events = await client.readAll(10, {
+  const events = await client.readAll({
     direction: FORWARDS,
     fromPosition: START,
+    maxCount: 10,
   });
 
   for (const resolvedEvent of events) {
@@ -181,10 +192,11 @@ export async function filterOutSystemEvents(client) {
 
 export async function readFromAllStreamResolvingLinkTos(client) {
   // region read-from-all-stream-resolving-link-Tos
-  const events = await client.readAll(10, {
+  const events = await client.readAll({
     direction: BACKWARDS,
     fromPosition: END,
     resolveLinkTos: true,
+    maxCount: 10,
   });
   // endregion read-from-all-stream-resolving-link-Tos
 

--- a/samples/grpc/nodejs/samples/server-side-filtering/index.js
+++ b/samples/grpc/nodejs/samples/server-side-filtering/index.js
@@ -2,15 +2,15 @@ import {
   START,
   eventTypeFilter,
   streamNameFilter,
+  excludeSystemEvents,
 } from "@eventstore/db-client";
 
 export async function subscribeToAllExcludeSystemEvents(client) {
   // region exclude-system
-  const excludeSystemEventsRegex = /^[^\$].*/;
   const subscription = client
     .subscribeToAll({
       fromRevision: START,
-      filter: eventTypeFilter({ regex: excludeSystemEventsRegex }),
+      filter: excludeSystemEvents(),
     })
     .on("data", function (resolvedEvent) {
       console.log(

--- a/samples/grpc/nodejs/yarn.lock
+++ b/samples/grpc/nodejs/yarn.lock
@@ -39,13 +39,14 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eventstore/db-client@0.0.0-alpha.12":
-  version "0.0.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@eventstore/db-client/-/db-client-0.0.0-alpha.12.tgz#1a8ab115ff7da7f96a2bee259c273b2604ad234c"
-  integrity sha512-7ykLyisEFXYM7p9K4/JqWZDCiCZn9jgp8vaQWfKnE015EQIsGdR4A3TK/kG5qtPpMJK83K9hiqOaHdDjqzIUdA==
+"@eventstore/db-client@0.0.0-alpha.17":
+  version "0.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/@eventstore/db-client/-/db-client-0.0.0-alpha.17.tgz#83f46ecaaf7ca4728d0c690406f96f0357e4b713"
+  integrity sha512-yRIEY/PK6rkKmk71tdsNht+idIlX9AMKZ6FnxMYLcPwJB7nxon8RpkN+/+xe8BavLn+qTNttozZf+pSHVVzOwA==
   dependencies:
     "@grpc/grpc-js" "^1.2.2"
     "@types/debug" "^4.1.5"
+    "@types/google-protobuf" "^3.7.4"
     "@types/node" "^12.12.47"
     debug "^4.3.1"
     google-protobuf "^3.14.0"
@@ -64,6 +65,11 @@
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
+
+"@types/google-protobuf@^3.7.4":
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.7.4.tgz#1621c50ceaf5aefa699851da8e0ea606a2943a39"
+  integrity sha512-6PjMFKl13cgB4kRdYtvyjKl8VVa0PXS2IdVxHhQ8GEKbxBkyJtSbaIeK1eZGjDKN7dvUh4vkOvU9FMwYNv4GQQ==
 
 "@types/node@^12.12.47":
   version "12.19.9"

--- a/samples/grpc/nodejs/yarn.lock
+++ b/samples/grpc/nodejs/yarn.lock
@@ -39,10 +39,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eventstore/db-client@0.0.0-alpha.17":
-  version "0.0.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/@eventstore/db-client/-/db-client-0.0.0-alpha.17.tgz#83f46ecaaf7ca4728d0c690406f96f0357e4b713"
-  integrity sha512-yRIEY/PK6rkKmk71tdsNht+idIlX9AMKZ6FnxMYLcPwJB7nxon8RpkN+/+xe8BavLn+qTNttozZf+pSHVVzOwA==
+"@eventstore/db-client@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@eventstore/db-client/-/db-client-1.0.0.tgz#1a60fb638f3268681037f77bd8c33a8a5bb14fdc"
+  integrity sha512-SpQCgGR3XVgxW2pT+4N+gOGP8gYrXaOL+Yt22SDiW43wH0WKupxmHM4ZDWVgqI9ADsnKxFGG8iDgi+NkZYtQ+A==
   dependencies:
     "@grpc/grpc-js" "^1.2.2"
     "@types/debug" "^4.1.5"


### PR DESCRIPTION
Update the NodeJS snippets to the latest NodeJS API changes: 
- `maxCount` in the read methods was moved to options 
- built-in `excludeSystemEvents` filter was added.