### PR TITLE
Documented Keep Alive settings for gRPC and database node.

### DIFF
--- a/docs/.vuepress/lib/validate.js
+++ b/docs/.vuepress/lib/validate.js
@@ -33,9 +33,9 @@ export async function validateGossip(nodes, value, callback) {
 }
 
 export function validateKeepAlive(value, callback) {
-    return true
+    return value === undefined || value >= -1
         ? ok(callback)
-        : error(callback, `${value} does not resolve to`);
+        : error(callback, `${value} has to be greater or equal to -1`);
 }
 
 export function ensureCaDomainMatch(dnsName, cert) {

--- a/docs/.vuepress/lib/validate.js
+++ b/docs/.vuepress/lib/validate.js
@@ -32,6 +32,12 @@ export async function validateGossip(nodes, value, callback) {
         : error(callback, `${value} does not resolve to ${notFound[0].extIp}`);
 }
 
+export function validateKeepAlive(value, callback) {
+    return true
+        ? ok(callback)
+        : error(callback, `${value} does not resolve to`);
+}
+
 export function ensureCaDomainMatch(dnsName, cert) {
     if (!cert || cert.selfSigned || dnsName === "" || cert.cn === "") return true;
     const caDomain = cert.cn.substring(2);

--- a/docs/.vuepress/modules/common/keepAlive.js
+++ b/docs/.vuepress/modules/common/keepAlive.js
@@ -1,0 +1,45 @@
+import {validateKeepAlive} from "../../lib/validate";
+
+function formatKeepAlive(name, value) {
+    console.log(value);
+    return value !== undefined ? `$${name}=${value};` : "";
+}
+
+export default class KeepAlive {
+    constructor() {
+        this.keepAliveInterval   = undefined;
+        this.keepAliveTimeout    = undefined;
+        
+        this.isEnabled           = true;
+        this.minKeepAlive        = -1;
+        this.maxKeepAlive        = Number.MAX_SAFE_INTEGER;
+    }
+
+    validate(value, callback) {
+        return validateKeepAlive(value, callback);
+    }
+
+    minKeepAliveTimeoutValueHelp() {
+        return this.isEnabled 
+            && this.keepAliveTimeout !== undefined && this.keepAliveTimeout < 10000
+            ? "We recommended setting keepAliveTimeout greater or equal to 10 000 ms."
+            : "";
+    }
+
+    minKeepAliveIntervalValueHelp() {
+        return this.isEnabled 
+            && this.keepAliveInterval !== undefined && this.keepAliveInterval < 10000
+            ? "We recommended setting keepAliveInterval greater or equal to 10 000 ms."
+            : "";
+    }
+
+    getConnectionStringValue() {
+        if(!this.isEnabled) {
+            return "&keepAliveInterval=-1&keepAliveTimeout=-1";
+        }
+        
+        return `${formatKeepAlive("keepAliveTimeout", this.keepAliveTimeout)}${formatKeepAlive("keepAliveInterval", this.keepAliveInterval)}`
+    }
+
+    
+}

--- a/docs/.vuepress/modules/common/keepAlive.js
+++ b/docs/.vuepress/modules/common/keepAlive.js
@@ -1,8 +1,14 @@
 import {validateKeepAlive} from "../../lib/validate";
 
 function formatKeepAlive(name, value) {
-    console.log(value);
     return value !== undefined ? `$${name}=${value};` : "";
+}
+
+function getKeepAliveValueHelp(isEnabled, name, value) {
+    return isEnabled 
+        && value !== undefined && value != -1 && value < 10000
+            ? `We recommend setting ${name} greater or equal to 10 000 ms.`
+            : "";
 }
 
 export default class KeepAlive {
@@ -20,17 +26,11 @@ export default class KeepAlive {
     }
 
     minKeepAliveTimeoutValueHelp() {
-        return this.isEnabled 
-            && this.keepAliveTimeout !== undefined && this.keepAliveTimeout < 10000
-            ? "We recommended setting keepAliveTimeout greater or equal to 10 000 ms."
-            : "";
+        return getKeepAliveValueHelp(this.isEnabled, "keepAliveTimeout", this.keepAliveTimeout);
     }
 
     minKeepAliveIntervalValueHelp() {
-        return this.isEnabled 
-            && this.keepAliveInterval !== undefined && this.keepAliveInterval < 10000
-            ? "We recommended setting keepAliveInterval greater or equal to 10 000 ms."
-            : "";
+        return getKeepAliveValueHelp(this.isEnabled, "keepAliveInterval", this.keepAliveInterval);
     }
 
     getConnectionStringValue() {

--- a/docs/.vuepress/modules/grpcClient/components/KeepAlive.vue
+++ b/docs/.vuepress/modules/grpcClient/components/KeepAlive.vue
@@ -1,0 +1,81 @@
+<template>
+  <transition name="slide">
+    <div v-show="keepAlive.isEnabled">
+      <el-form
+              :model="keepAlive"
+              ref="keepAliveForm"
+              label-width="240px"
+              @validate="checkField"
+      >
+        <el-form-item
+          label="KeepAlive Interval (ms)"
+          prop="keepAliveInterval"
+          :rules="[
+            {validator: validateKeepAlive, trigger: 'blur'}
+          ]"
+        >
+          <el-col :span="5">
+              <el-input-number
+                placeholder="10 000"
+                v-model="keepAlive.keepAliveInterval"
+                :min="keepAlive.minKeepAlive"
+                :max="keepAlive.maxKeepAlive"
+                :controls="false"
+                clearable
+              >
+              </el-input-number>
+          </el-col>
+          <el-col :span="10" class="form-help">
+            {{ keepAlive.minKeepAliveIntervalValueHelp() }}
+          </el-col>
+        </el-form-item>
+        <el-form-item 
+          label="KeepAlive Timeout (ms)"
+          prop="keepAliveTimeout"
+          :rules="[
+            {validator: validateKeepAlive, trigger: 'blur'}
+          ]"
+        >
+          <el-col :span="5">
+              <el-input-number
+                placeholder="10 000"
+                v-model="keepAlive.keepAliveTimeout"
+                :min="keepAlive.minKeepAlive"
+                :controls="false"
+                :max="keepAlive.maxKeepAlive"
+                clearable
+              >
+              </el-input-number>
+          </el-col>
+          <el-col :span="10" class="form-help">
+            {{ keepAlive.minKeepAliveTimeoutValueHelp() }}
+          </el-col>
+        </el-form-item>
+      </el-form>
+    </div>
+  </transition>
+</template>
+
+<script>
+import validationMixin from "../../common/validationMixin";
+
+export default {
+    name:     "KeepAlive",
+    mixins:   [validationMixin],
+    props:    {
+        keepAlive: Object
+    },
+    methods:  {
+        validateKeepAlive(rule, value, callback) {
+            this.keepAlive.validate(value, callback);
+        },
+        async validate() {
+            try {
+                await this.$refs.keepAliveForm.validate();
+            } catch {
+            }
+        }
+    }
+}
+</script>
+

--- a/docs/.vuepress/modules/grpcClient/components/Manual.vue
+++ b/docs/.vuepress/modules/grpcClient/components/Manual.vue
@@ -22,12 +22,17 @@
       </el-form-item>
 
       <el-form-item label="KeepAlive:" prop="keepAlive.isEnabled">
-        <el-switch
-                v-model="keepAlive.isEnabled"
-                :disabled="disableKeepAlive"
-                active-text="Enabled"
-                inactive-text="Disabled">
-        </el-switch>
+        <el-col :span="22">
+          <el-switch
+                  v-model="keepAlive.isEnabled"
+                  :disabled="disableKeepAlive"
+                  active-text="Enabled"
+                  inactive-text="Disabled">
+          </el-switch>
+        </el-col>
+        <el-col :span="12">
+          Read more in <a href="/server/v20/server/networking/http.html#keepalive-pings" target="_blank">KeepAlive settings docs</a>
+        </el-col>
       </el-form-item>
 
       <KeepAlive ref="keepAliveForm" :keepAlive="keepAlive"/>

--- a/docs/.vuepress/modules/grpcClient/components/Manual.vue
+++ b/docs/.vuepress/modules/grpcClient/components/Manual.vue
@@ -21,6 +21,17 @@
         </el-switch>
       </el-form-item>
 
+      <el-form-item label="KeepAlive:" prop="keepAlive.isEnabled">
+        <el-switch
+                v-model="keepAlive.isEnabled"
+                :disabled="disableKeepAlive"
+                active-text="Enabled"
+                inactive-text="Disabled">
+        </el-switch>
+      </el-form-item>
+
+      <KeepAlive ref="keepAliveForm" :keepAlive="keepAlive"/>
+
       <ClusterConnection/>
 
     </el-form>
@@ -30,16 +41,19 @@
 <script>
 import connection from "../domain/connection";
 import ClusterConnection from "./ClusterConnection";
+import KeepAlive from "./KeepAlive";
 import {isTrue} from "../../../lib/parse";
 
 export default {
     name:       "Manual",
-    components: {ClusterConnection},
+    components: {ClusterConnection, KeepAlive},
     computed:   {
-        state:           () => connection,
-        disableSecurity: () => connection.cloud,
-        cluster:         connection.extendedProperty("cluster", "changeTopology"),
-        secure:          connection.extendedProperty("secure", "changeSecurity"),
+        state:            () => connection,
+        disableSecurity:  () => connection.cloud,
+        disableKeepAlive: () => connection.cloud,
+        cluster:          connection.extendedProperty("cluster", "changeTopology"),
+        secure:           connection.extendedProperty("secure", "changeSecurity"),
+        keepAlive:        connection.extendedProperty("keepAlive", "changeKeepAlive")
     },
     mounted() {
         connection.changeTopology(isTrue(this.$route.query.cluster));

--- a/docs/.vuepress/modules/grpcClient/domain/connection.js
+++ b/docs/.vuepress/modules/grpcClient/domain/connection.js
@@ -1,9 +1,10 @@
 import Vue from "vue";
 import Gossip from "../../common/gossip";
-import {DnsGossip, SeedGossip} from "../../common/gossipTypes";
+import {DnsGossip} from "../../common/gossipTypes";
 import ClientNode from "./clientNode";
 import {safe} from "../../common/strings";
 import properties from "../../common/properties";
+import KeepAlive from "../../common/keepAlive";
 
 export default new Vue({
     data() {
@@ -11,6 +12,7 @@ export default new Vue({
             cluster: true,
             cloud: false,
             secure: true,
+            keepAlive: new KeepAlive(),
             clusterId: "",
             gossip: new Gossip("Client", "clients", false, true),
             gossipPort: 2113,
@@ -54,6 +56,9 @@ export default new Vue({
         },
         changeSecurity(secure) {
             this.secure = secure;
+        },
+        changeKeepAlive(keepAlive) {
+            this.keepAlive = keepAlive;
         },
         populateCloudNodes() {
             if (!this.cloud) return;
@@ -105,7 +110,10 @@ export default new Vue({
                 ? `${safe(this.gossip.dnsName)}:${this.gossipPort}`
                 : this.nodes.map(x => `${safe(x.address)}:${x.port}`).join(",");
             const scheme = isDns ? "esdb+discover" : "esdb";
-            return gossip && gossip !== "" ? `${scheme}://${gossip}?tls=${this.secure}` : null;
+
+            const keepAlive = this.keepAlive.getConnectionStringValue();
+
+            return gossip && gossip !== "" ? `${scheme}://${gossip}?tls=${this.secure}${keepAlive}` : null;
         },
     },
     created() {

--- a/docs/server/v20/server/networking/http.md
+++ b/docs/server/v20/server/networking/http.md
@@ -38,7 +38,7 @@ You can customise the following Keepalive settings:
 
 ### keepAliveInterval
 
-KeepAlive interval controls the period (in milliseconds) after which a keepalive ping is sent on the transport.
+After a duration of `keepAliveInterval` (in milliseconds), if the server doesn't see any activity, it pings the client to see if the transport is still alive.
 
 To disable the Keepalive ping, you need to set the `keepAliveInterval` value to `-1`.
 
@@ -52,7 +52,7 @@ To disable the Keepalive ping, you need to set the `keepAliveInterval` value to 
 
 ### keepAliveTimeout
 
-KeepAlive timeout controls the amount of time (in milliseconds) the sender of the keepalive ping waits for an acknowledgement. If it does not receive an acknowledgement within this time, it will close the connection.
+After having pinged for keepalive check, the server waits for a duration of `keepAliveTimeout` (in milliseconds). If no activity is seen even after that, the connection is closed.
 
 | Format               | Syntax |
 | :------------------- | :----- |

--- a/docs/server/v20/server/networking/http.md
+++ b/docs/server/v20/server/networking/http.md
@@ -62,6 +62,4 @@ KeepAlive timeout controls the amount of time (in milliseconds) the sender of th
 
 **Default**: `10000`
 
-
 As a general rule, we do not recommend putting EventStoreDB behind a load balancer. However, if you are using it and want to benefit from the Keepalive feature, then you should make sure if the compatible settings are properly set. Some load balancers may also override the Keepalive settings. Most of them require setting the idle timeout larger/longer than the `keepAliveTimeout`. We suggest checking the load balancer documentation before using Keepalive pings. 
-


### PR DESCRIPTION
1. Added KeepAlive settings in gRPC client configuration wizard: https://deploy-preview-276--developers-eventstore.netlify.app/clients/grpc/getting-started/

![obraz](https://user-images.githubusercontent.com/5562528/108869981-01f36680-75f8-11eb-9f83-d6fc22231b01.png)

2. Added information with the description in the database node configuration: https://deploy-preview-276--developers-eventstore.netlify.app/server/v20/server/networking/http.html#keepalive-pings

Fixes #253 