### PR TITLE
Configured import of 21.2 docs from the main database repository.

### DIFF
--- a/docs/clients/grpc/appending-events/README.md
+++ b/docs/clients/grpc/appending-events/README.md
@@ -9,11 +9,11 @@ The simplest way to append an event to EventStoreDB is to create an `EventData` 
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/appending-events/Program.cs#append-to-stream
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/appending-events/Program.cs#append-to-stream
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/appending_events/AppendingEvents.java#append-to-stream
+<<< @/docs/clients/java/generated/1.0.0/samples/appending_events/AppendingEvents.java#append-to-stream
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -46,11 +46,11 @@ For example:
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/appending-events/Program.cs#append-duplicate-event
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/appending-events/Program.cs#append-duplicate-event
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/appending_events/AppendingEvents.java#append-duplicate-event
+<<< @/docs/clients/java/generated/1.0.0/samples/appending_events/AppendingEvents.java#append-duplicate-event
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -95,11 +95,11 @@ For example if we try and append the same record twice expecting both times that
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/appending-events/Program.cs#append-with-no-stream
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/appending-events/Program.cs#append-with-no-stream
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/appending_events/AppendingEvents.java#append-with-no-stream
+<<< @/docs/clients/java/generated/1.0.0/samples/appending_events/AppendingEvents.java#append-with-no-stream
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -121,11 +121,11 @@ This check can be used to implement optimistic concurrency. When you retrieve a 
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/appending-events/Program.cs#append-with-concurrency-check
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/appending-events/Program.cs#append-with-concurrency-check
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/appending_events/AppendingEvents.java#append-with-concurrency-check
+<<< @/docs/clients/java/generated/1.0.0/samples/appending_events/AppendingEvents.java#append-with-concurrency-check
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -146,11 +146,11 @@ You can provide user credentials to be used to append the data as follows. This 
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/appending-events/Program.cs#overriding-user-credentials
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/appending-events/Program.cs#overriding-user-credentials
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/appending_events/AppendingEvents.java#overriding-user-credentials
+<<< @/docs/clients/java/generated/1.0.0/samples/appending_events/AppendingEvents.java#overriding-user-credentials
 </xode-block>
 <xode-block title="NodeJS">
 

--- a/docs/clients/grpc/getting-started/connecting.md
+++ b/docs/clients/grpc/getting-started/connecting.md
@@ -73,11 +73,11 @@ First thing first, we need a client.
 <xode-group>
 <xode-block title="C#" code="connectionString">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/quick-start/Program.cs#createClient
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/quick-start/Program.cs#createClient
 </xode-block>
 <xode-block title="Java" code="connectionString">
 
-<<< @/docs/clients/java/generated/0.7/samples/quick_start/QuickStart.java#createClient
+<<< @/docs/clients/java/generated/1.0.0/samples/quick_start/QuickStart.java#createClient
 </xode-block>
 <xode-block title="NodeJS" code="connectionString">
 
@@ -105,11 +105,11 @@ The code snippet below creates an event object instance, serializes it and puts 
 
 <xode-group>
 <xode-block title="C#">
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/quick-start/Program.cs#createEvent
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/quick-start/Program.cs#createEvent
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/quick_start/QuickStart.java#createEvent
+<<< @/docs/clients/java/generated/1.0.0/samples/quick_start/QuickStart.java#createEvent
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -130,11 +130,11 @@ In the snippet below, we append the event to the stream `some-stream`.
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/quick-start/Program.cs#appendEvents
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/quick-start/Program.cs#appendEvents
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/quick_start/QuickStart.java#appendEvents
+<<< @/docs/clients/java/generated/1.0.0/samples/quick_start/QuickStart.java#appendEvents
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -155,11 +155,11 @@ Finally, we can read events back from the `some-stream` stream.
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/quick-start/Program.cs#readStream
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/quick-start/Program.cs#readStream
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/quick_start/QuickStart.java#readStream
+<<< @/docs/clients/java/generated/1.0.0/samples/quick_start/QuickStart.java#readStream
 </xode-block>
 <xode-block title="NodeJS">
 

--- a/docs/clients/grpc/reading-events/reading-from-a-stream.md
+++ b/docs/clients/grpc/reading-events/reading-from-a-stream.md
@@ -9,11 +9,11 @@ The simplest way to read a stream forwards is to supply a stream name, direction
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#read-from-stream
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#read-from-stream
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#read-from-stream
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#read-from-stream
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -30,11 +30,11 @@ This will return an enumerable that can be iterated on:
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#iterate-stream
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#iterate-stream
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#iterate-stream
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#iterate-stream
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -66,11 +66,11 @@ The credentials used to read the data can be supplied. to be used by the subscri
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#overriding-user-credentials
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#overriding-user-credentials
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#overriding-user-credentials
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#overriding-user-credentials
 </xode-block>
 <xode-block title="NodeJS"> 
 
@@ -89,11 +89,11 @@ As well as providing a `StreamPosition` you can also provide a specific stream r
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#read-from-stream-position
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#read-from-stream-position
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#read-from-stream-position
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#read-from-stream-position
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -112,11 +112,11 @@ As well as being able to read a stream forwards you can also go backwards. When 
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#reading-backwards 
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#reading-backwards 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#reading-backwards
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#reading-backwards
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -140,11 +140,11 @@ It is important to check the value of this field before attempting to iterate an
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#checking-for-stream-presence
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#checking-for-stream-presence
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#checking-for-stream-presence
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#checking-for-stream-presence
 </xode-block>
 <xode-block title="NodeJS">
 

--- a/docs/clients/grpc/reading-events/reading-from-the-all-stream.md
+++ b/docs/clients/grpc/reading-events/reading-from-the-all-stream.md
@@ -10,11 +10,11 @@ The simplest way to read the `$all` stream forwards is to supply a direction and
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#read-from-all-stream
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#read-from-all-stream
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#read-from-all-stream
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#read-from-all-stream
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -31,11 +31,11 @@ This will return an AsyncEnumerable that can be iterated on:
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#read-from-all-stream-iterate
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#read-from-all-stream-iterate
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#read-from-all-stream-iterate
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#read-from-all-stream-iterate
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -60,12 +60,12 @@ When using projections to create new events you can set whether the generated ev
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#read-from-all-stream-resolving-link-Tos
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#read-from-all-stream-resolving-link-Tos
 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#read-from-all-stream-resolving-link-Tos
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#read-from-all-stream-resolving-link-Tos
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -87,11 +87,11 @@ The credentials used to read the data can be supplied. to be used by the subscri
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#read-all-overriding-user-credentials
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#read-all-overriding-user-credentials
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#read-all-overriding-user-credentials
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#read-all-overriding-user-credentials
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -110,11 +110,11 @@ As well as being able to read a stream forwards you can also go backwards. When 
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#read-from-all-stream-backwards 
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#read-from-all-stream-backwards 
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#read-from-all-stream-backwards 
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#read-from-all-stream-backwards 
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -139,11 +139,11 @@ All system events begin with `$` or `$$` and can be easily ignored by checking t
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/reading-events/Program.cs#ignore-system-events
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/reading-events/Program.cs#ignore-system-events
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/reading_events/ReadingEvents.java#ignore-system-events
+<<< @/docs/clients/java/generated/1.0.0/samples/reading_events/ReadingEvents.java#ignore-system-events
 </xode-block>
 <xode-block title="NodeJS">
 

--- a/docs/clients/grpc/subscribing-to-streams/README.md
+++ b/docs/clients/grpc/subscribing-to-streams/README.md
@@ -17,11 +17,11 @@ The simplest stream subscription looks like the following :
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/subscribing-to-streams/Program.cs#subscribe-to-stream
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/subscribing-to-streams/Program.cs#subscribe-to-stream
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream
+<<< @/docs/clients/java/generated/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -42,11 +42,11 @@ Subscribing to `$all` is much the same as subscribing to a single stream. The ha
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/subscribing-to-streams/Program.cs#subscribe-to-all
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/subscribing-to-streams/Program.cs#subscribe-to-all
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all
+<<< @/docs/clients/java/generated/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -79,11 +79,11 @@ The following subscribes to the stream `some-stream` at position `20`, this mean
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/subscribing-to-streams/Program.cs#subscribe-to-stream-from-position
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/subscribing-to-streams/Program.cs#subscribe-to-stream-from-position
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-from-position
+<<< @/docs/clients/java/generated/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-from-position
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -106,11 +106,11 @@ Please note that this position will need to be a legitimate position in `$all`.
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/subscribing-to-streams/Program.cs#subscribe-to-all-from-position
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/subscribing-to-streams/Program.cs#subscribe-to-all-from-position
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-from-position
+<<< @/docs/clients/java/generated/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-from-position
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -129,11 +129,11 @@ You can subscribe to a stream to get live updates by subscribing to the end of t
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/subscribing-to-streams/Program.cs#subscribe-to-stream-live
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/subscribing-to-streams/Program.cs#subscribe-to-stream-live
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-live
+<<< @/docs/clients/java/generated/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-live
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -150,11 +150,11 @@ And the same works with `$all` :
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/subscribing-to-streams/Program.cs#subscribe-to-all-live
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/subscribing-to-streams/Program.cs#subscribe-to-all-live
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-live
+<<< @/docs/clients/java/generated/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-live
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -183,11 +183,11 @@ When reading a stream you can specify whether to resolve link-to's or not. By de
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/subscribing-to-streams/Program.cs#subscribe-to-stream-resolving-linktos
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/subscribing-to-streams/Program.cs#subscribe-to-stream-resolving-linktos
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-resolving-linktos
+<<< @/docs/clients/java/generated/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-resolving-linktos
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -222,11 +222,11 @@ An application, which hosts the subscription, can go offline for a period of tim
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/subscribing-to-streams/Program.cs#subscribe-to-stream-subscription-dropped
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/subscribing-to-streams/Program.cs#subscribe-to-stream-subscription-dropped
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-subscription-dropped
+<<< @/docs/clients/java/generated/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-stream-subscription-dropped
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -245,11 +245,11 @@ When subscribed to `$all` you want to keep the position of the event in the `$al
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/subscribing-to-streams/Program.cs#subscribe-to-all-subscription-dropped
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/subscribing-to-streams/Program.cs#subscribe-to-all-subscription-dropped
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-subscription-dropped
+<<< @/docs/clients/java/generated/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java#subscribe-to-all-subscription-dropped
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -272,11 +272,11 @@ A simple stream prefix filter looks like this:
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/subscribing-to-streams/Program.cs#stream-prefix-filtered-subscription
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/subscribing-to-streams/Program.cs#stream-prefix-filtered-subscription
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/subscribing_to_stream/SubscribingToStream.java#stream-prefix-filtered-subscription
+<<< @/docs/clients/java/generated/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java#stream-prefix-filtered-subscription
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -299,11 +299,11 @@ The code below shows how you can provide user credentials for a subscription. Wh
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/subscribing-to-streams/Program.cs#overriding-user-credentials
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/subscribing-to-streams/Program.cs#overriding-user-credentials
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/subscribing_to_stream/SubscribingToStream.java#overriding-user-credentials
+<<< @/docs/clients/java/generated/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java#overriding-user-credentials
 </xode-block>
 <xode-block title="NodeJS">
 

--- a/docs/clients/grpc/subscribing-to-streams/filtering.md
+++ b/docs/clients/grpc/subscribing-to-streams/filtering.md
@@ -15,11 +15,11 @@ There are a number of events in EventStoreDB called system events. These are pre
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/server-side-filtering/Program.cs#exclude-system
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/server-side-filtering/Program.cs#exclude-system
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/server_side_filtering/ServerSideFiltering.java#exclude-system
+<<< @/docs/clients/java/generated/1.0.0/samples/server_side_filtering/ServerSideFiltering.java#exclude-system
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -46,11 +46,11 @@ If you want to filter by prefix pass in a `SubscriptionFilterOptions` to the sub
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/server-side-filtering/Program.cs#event-type-prefix
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/server-side-filtering/Program.cs#event-type-prefix
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/server_side_filtering/ServerSideFiltering.java#event-type-prefix
+<<< @/docs/clients/java/generated/1.0.0/samples/server_side_filtering/ServerSideFiltering.java#event-type-prefix
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -71,11 +71,11 @@ If you want to subscribe to multiple event types then it might be better to prov
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/server-side-filtering/Program.cs#event-type-regex
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/server-side-filtering/Program.cs#event-type-regex
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/server_side_filtering/ServerSideFiltering.java#event-type-regex
+<<< @/docs/clients/java/generated/1.0.0/samples/server_side_filtering/ServerSideFiltering.java#event-type-regex
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -100,11 +100,11 @@ If you want to filter by prefix pass in a `SubscriptionFilterOptions` to the sub
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/server-side-filtering/Program.cs#stream-prefix
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/server-side-filtering/Program.cs#stream-prefix
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/server_side_filtering/ServerSideFiltering.java#stream-prefix
+<<< @/docs/clients/java/generated/1.0.0/samples/server_side_filtering/ServerSideFiltering.java#stream-prefix
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -125,11 +125,11 @@ If you want to subscribe to multiple streams then it might be better to provide 
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/server-side-filtering/Program.cs#stream-regex
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/server-side-filtering/Program.cs#stream-regex
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/server_side_filtering/ServerSideFiltering.java#stream-regex
+<<< @/docs/clients/java/generated/1.0.0/samples/server_side_filtering/ServerSideFiltering.java#stream-regex
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -154,11 +154,11 @@ To make use of it set up `checkpointReached` on the `SubscriptionFilterOptions` 
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/server-side-filtering/Program.cs#checkpoint
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/server-side-filtering/Program.cs#checkpoint
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/server_side_filtering/ServerSideFiltering.java#checkpoint
+<<< @/docs/clients/java/generated/1.0.0/samples/server_side_filtering/ServerSideFiltering.java#checkpoint
 </xode-block>
 <xode-block title="NodeJS">
 
@@ -177,11 +177,11 @@ To make use of it set up `checkpointReached` on the `SubscriptionFilterOptions` 
 <xode-group>
 <xode-block title="C#">
 
-<<< @/docs/clients/dotnet/generated/v20.6.1/samples/server-side-filtering/Program.cs#checkpoint-with-interval
+<<< @/docs/clients/dotnet/generated/21.2.0/samples/server-side-filtering/Program.cs#checkpoint-with-interval
 </xode-block>
 <xode-block title="Java">
 
-<<< @/docs/clients/java/generated/0.7/samples/server_side_filtering/ServerSideFiltering.java#checkpoint-with-interval
+<<< @/docs/clients/java/generated/1.0.0/samples/server_side_filtering/ServerSideFiltering.java#checkpoint-with-interval
 </xode-block>
 <xode-block title="NodeJS">
 

--- a/docs/server/versions.json
+++ b/docs/server/versions.json
@@ -6,7 +6,7 @@
     "versions": [
       {
         "version": "21.2",
-        "path": "generated/v21.2/docs"
+        "path": "generated/21.2/docs"
       },
       {
         "version": "20.10 LTS",

--- a/docs/server/versions.json
+++ b/docs/server/versions.json
@@ -5,6 +5,10 @@
     "basePath": "server",
     "versions": [
       {
+        "version": "21.2",
+        "path": "generated/v21.2/docs"
+      },
+      {
         "version": "20.10 LTS",
         "path": "v20/server"
       },

--- a/import/import-client-docs.js
+++ b/import/import-client-docs.js
@@ -74,7 +74,7 @@ async function copyDocsAndSamples(clientRepo, repoLocation, destinationPath, id,
     if (samplesRelativePath)
         await copySamples(repoLocation, destinationPathWithId, samplesRelativePath);
 
-    return {path: path.join('generated', id), version: id.substr(1)};
+    return {path: path.join('generated', id), version: id};
 }
 
 async function copyDocs(repoLocation, destinationPathWithId, relativePath) {

--- a/import/import-client-docs.js
+++ b/import/import-client-docs.js
@@ -21,8 +21,6 @@ async function sh(cmd) {
     });
 }
 
-let deployCurrent = true;
-
 async function safeRmdir(path) {
     if (fs.existsSync(path)) {
         await del(path);
@@ -64,13 +62,32 @@ async function replaceFileExtensions(samplesDir,  from, to) {
     await sh(command);
 }
 
-async function copySamples(clientRepo, repoLocation, destinationPath, id, tag, relativePath) {
-    log.info(`checking out ${tag}...`);
-    await clientRepo.checkout(tag);
+async function copyDocsAndSamples(clientRepo, repoLocation, destinationPath, id, tagOrBranch, samplesRelativePath, docsRelativePath) {
+    log.info(`checking out ${tagOrBranch}...`);
+    await clientRepo.checkout(tagOrBranch);
+    
+    const destinationPathWithId = path.join(destinationPath, id);
 
+    if (docsRelativePath)
+        await copyDocs(repoLocation, destinationPathWithId, docsRelativePath);
+
+    if (samplesRelativePath)
+        await copySamples(repoLocation, destinationPathWithId, samplesRelativePath);
+
+    return {path: path.join('generated', id), version: id.substr(1)};
+}
+
+async function copyDocs(repoLocation, destinationPathWithId, relativePath) {
     const pathElements = [repoLocation, ...relativePath];
 
-    const destinationPathWithId = path.join(destinationPath, id);
+    const docsDestinationPath = path.join(destinationPathWithId, 'docs');
+
+    await tryCopy(pathElements, docsDestinationPath);
+}
+
+async function copySamples(repoLocation, destinationPathWithId, relativePath) {
+    const pathElements = [repoLocation, ...relativePath];
+
     const samplesDestinationPath = path.join(destinationPathWithId, 'samples');
 
     const wereSamplesCopied = await tryCopy(pathElements, samplesDestinationPath);
@@ -81,8 +98,6 @@ async function copySamples(clientRepo, repoLocation, destinationPath, id, tag, r
     
     await replaceFileExtensions('docs', 'rs', 'rust');
     await replaceCodePath(destinationPathWithId, samplesDestinationPath);
-
-    return {path: path.join('generated', id), version: id.substr(1) + ' gRPC'};
 }
 
 async function main() {
@@ -114,15 +129,16 @@ async function main() {
             .split('\n')
             .filter(i => i)
 
-        if (deployCurrent) {
-            definition[0].versions.push(await copySamples(clientRepo, repoLocation, samplesLocation, tags.slice(-1)[0], repo.currentBranch, repo.relativePath));
+        if (repo.deployCurrent) {
+            definition[0].versions.push(await copyDocsAndSamples(clientRepo, repoLocation, samplesLocation, repo.version || tags.slice(-1)[0], repo.currentBranch, repo.samplesRelativePath, repo.docsRelativePath));
         }
+        else {
+            for (let i = 0; i < tags.length - 1; i++) {
+                const version = await copyDocsAndSamples(clientRepo, repoLocation, samplesLocation, tags[i], tags[i + 1], repo.samplesRelativePath, repo.docsRelativePath);
 
-        for (let i = 0; i < tags.length - 1; i++) {
-            const version = await copySamples(clientRepo, repoLocation, samplesLocation, tags[i], tags[i + 1], repo.relativePath);
-
-            if (version !== undefined) {
-                definition[0].versions.push(version);
+                if (version !== undefined) {
+                    definition[0].versions.push(version);
+                }
             }
         }
 

--- a/import/repos.json
+++ b/import/repos.json
@@ -6,7 +6,7 @@
     "docsRelativePath": ["docs"],
     "currentBranch": "docs_for_v21.2",
     "repo": "https://github.com/EventStore/EventStore.git",
-    "version": "v21.2",
+    "version": "21.2",
     "deployCurrent": true
   },
   {
@@ -15,7 +15,8 @@
     "basePath": "clients/dotnet",
     "samplesRelativePath": ["samples"],
     "currentBranch": "master",
-    "repo": "https://github.com/EventStore/EventStore-Client-Dotnet.git",
+    "repo": "https://github.com/EventStore/EventStore-Client-Dotnet.git",    
+    "version": "21.2.0",
     "deployCurrent": true
   },
   {
@@ -25,6 +26,7 @@
     "samplesRelativePath": ["db-client-java","src","test","java","com","eventstore","dbclient", "samples"],
     "currentBranch": "trunk",
     "repo": "https://github.com/EventStore/EventStoreDB-Client-Java.git",
+    "version": "1.0.0",
     "deployCurrent": true
   },
   {
@@ -34,6 +36,7 @@
     "samplesRelativePath": ["examples"],
     "currentBranch": "master",
     "repo": "https://github.com/EventStore/EventStoreDB-Client-Rust.git",
+    "version": "1.0.0",
     "deployCurrent": true
   }
 ]

--- a/import/repos.json
+++ b/import/repos.json
@@ -1,26 +1,39 @@
 [
   {
+    "id": "server",
+    "group": "Server",
+    "basePath": "server",
+    "docsRelativePath": ["docs"],
+    "currentBranch": "docs_for_v21.2",
+    "repo": "https://github.com/EventStore/EventStore.git",
+    "version": "v21.2",
+    "deployCurrent": true
+  },
+  {
     "id": "dotnet-client",
     "group": ".NET SDK",
     "basePath": "clients/dotnet",
-    "relativePath": ["samples"],
+    "samplesRelativePath": ["samples"],
     "currentBranch": "master",
-    "repo": "https://github.com/EventStore/EventStore-Client-Dotnet.git"
+    "repo": "https://github.com/EventStore/EventStore-Client-Dotnet.git",
+    "deployCurrent": true
   },
   {
     "id": "java-client",
     "group": "Java SDK",
     "basePath": "clients/java",
-    "relativePath": ["db-client-java","src","test","java","com","eventstore","dbclient", "samples"],
+    "samplesRelativePath": ["db-client-java","src","test","java","com","eventstore","dbclient", "samples"],
     "currentBranch": "trunk",
-    "repo": "https://github.com/EventStore/EventStoreDB-Client-Java.git"
+    "repo": "https://github.com/EventStore/EventStoreDB-Client-Java.git",
+    "deployCurrent": true
   },
   {
     "id": "rust-client",
     "group": "Rust SDK",
     "basePath": "clients/rust",
-    "relativePath": ["examples"],
+    "samplesRelativePath": ["examples"],
     "currentBranch": "master",
-    "repo": "https://github.com/EventStore/EventStoreDB-Client-Rust.git"
+    "repo": "https://github.com/EventStore/EventStoreDB-Client-Rust.git",
+    "deployCurrent": true
   }
 ]

--- a/import/repos.json
+++ b/import/repos.json
@@ -4,7 +4,7 @@
     "group": "Server",
     "basePath": "server",
     "docsRelativePath": ["docs"],
-    "currentBranch": "docs_for_v21.2",
+    "currentBranch": "master",
     "repo": "https://github.com/EventStore/EventStore.git",
     "version": "21.2",
     "deployCurrent": true


### PR DESCRIPTION
Configured import of 21.2 docs from the main database repository.

Updated import-client-docs.js script to support docs import again.

See related PR: https://github.com/EventStore/EventStore/pull/2831.

Fixes #284 