### PR TITLE
Fixed "Event Store Cloud" name in the cloud docs (e.g. usages of "EventStoreDB Cloud")

### DIFF
--- a/docs/cloud/automation/README.md
+++ b/docs/cloud/automation/README.md
@@ -1,6 +1,6 @@
 # Cloud automation
 
-In addition to the [Cloud console][cloud console], EventStoreDB Cloud provides the API, a [Terraform provider][terraform_registry], 
+In addition to the [Cloud console][cloud console], Event Store Cloud provides the API, a [Terraform provider][terraform_registry], 
 as well as a [CLI tool][esc_cli github] to automate any operation accessible from the console. 
 
 ## Licence

--- a/docs/cloud/automation/terraform.md
+++ b/docs/cloud/automation/terraform.md
@@ -65,15 +65,15 @@ The Event Store Cloud provider must be configured with an access token. There ar
 | `token`           | `ESC_TOKEN`          | *Required*, your access token for Event Store Cloud.                                                                |
 | `organization_id` | `ESC_ORG_ID`         | *Required*, the identifier of your Event Store Cloud organization.                                                  |
 | `url`             | `ESC_URL`            | *Optional*, the URL of the Event Store Cloud API. This defaults to the public cloud instance of Event Store Cloud.  |
-| `token_store`     | `ESC_TOKEN_STORE`    | *Optional*, the location on the local filesystem of the token cache. This is shared with the EventStoreDB Cloud CLI. |
+| `token_store`     | `ESC_TOKEN_STORE`    | *Optional*, the location on the local filesystem of the token cache. This is shared with the Event Store Cloud CLI. |
 
                                                                                                                                                                        
 
 ### Obtaining the `token`
 
-You can can use the [cloud console][cloud console tokens] or the [EventStoreDB Cloud CLI][esc cli github releases] to obtain a token
+You can can use the [cloud console][cloud console tokens] or the [Event Store Cloud CLI][esc cli github releases] to obtain a token
 
-The command to obtain a token from the [EventStoreDB Cloud CLI][esc cli github releases] is:
+The command to obtain a token from the [Event Store Cloud CLI][esc cli github releases] is:
 
  ``` bash
  esc access tokens create --email <email>
@@ -90,9 +90,9 @@ In the cloud console:
 
 ### Obtaining the `organization_id`
 
-You can use the [cloud console][cloud console organizations] or the [EventStoreDB Cloud CLI][esc cli github releases] to find your organization id.
+You can use the [cloud console][cloud console organizations] or the [Event Store Cloud CLI][esc cli github releases] to find your organization id.
 
-The command to obtain the organization from the [EventStoreDB Cloud CLI][esc cli github releases] is:
+The command to obtain the organization from the [Event Store Cloud CLI][esc cli github releases] is:
 
 ``` bash
  esc resources organizations list

--- a/docs/cloud/automation/terraform.md
+++ b/docs/cloud/automation/terraform.md
@@ -65,15 +65,15 @@ The Event Store Cloud provider must be configured with an access token. There ar
 | `token`           | `ESC_TOKEN`          | *Required*, your access token for Event Store Cloud.                                                                |
 | `organization_id` | `ESC_ORG_ID`         | *Required*, the identifier of your Event Store Cloud organization.                                                  |
 | `url`             | `ESC_URL`            | *Optional*, the URL of the Event Store Cloud API. This defaults to the public cloud instance of Event Store Cloud.  |
-| `token_store`     | `ESC_TOKEN_STORE`    | *Optional*, the location on the local filesystem of the token cache. This is shared with the Event Store Cloud CLI. |
+| `token_store`     | `ESC_TOKEN_STORE`    | *Optional*, the location on the local filesystem of the token cache. This is shared with the EventStoreDB Cloud CLI. |
 
                                                                                                                                                                        
 
 ### Obtaining the `token`
 
-You can can use the [cloud console][cloud console tokens] or the [EvenStoreDB Cloud CLI][esc cli github releases] to obtain a token
+You can can use the [cloud console][cloud console tokens] or the [EventStoreDB Cloud CLI][esc cli github releases] to obtain a token
 
-The command to obtain a token from the [EvenStoreDB Cloud CLI][esc cli github releases] is:
+The command to obtain a token from the [EventStoreDB Cloud CLI][esc cli github releases] is:
 
  ``` bash
  esc access tokens create --email <email>
@@ -90,9 +90,9 @@ In the cloud console:
 
 ### Obtaining the `organization_id`
 
-You can use the [cloud console][cloud console organizations] or the [EvenStoreDB Cloud CLI][esc cli github releases] to find your organization id.
+You can use the [cloud console][cloud console organizations] or the [EventStoreDB Cloud CLI][esc cli github releases] to find your organization id.
 
-The command to obtain the organization from the [EvenStoreDB Cloud CLI][esc cli github releases] is:
+The command to obtain the organization from the [EventStoreDB Cloud CLI][esc cli github releases] is:
 
 ``` bash
  esc resources organizations list

--- a/docs/cloud/intro/README.md
+++ b/docs/cloud/intro/README.md
@@ -1,16 +1,16 @@
-# EventStoreDB Cloud
+# Event Store Cloud
 
 ::: warning Preview notice
-EventStoreDB Cloud is currently in preview. Read more about the Preview phase [here](preview.md).
+Event Store Cloud is currently in preview. Read more about the Preview phase [here](preview.md).
 :::
 
-EventStoreDB Cloud allows you to deploy a managed EventStoreDB cluster in AWS, GCP, and Azure. The cloud cluster is optimised for the specific cloud provider and provisioned as a multi-zone VM set.
+Event Store Cloud allows you to deploy a managed EventStoreDB cluster in AWS, GCP, and Azure. The cloud cluster is optimised for the specific cloud provider and provisioned as a multi-zone VM set.
 
 ::: tip Learn more
 Not using Event Store Cloud and want to learn more? Find more information and sign up links [on our website](https://www.eventstore.com/event-store-cloud).
 :::
 
-As a customer of EventStoreDB Cloud you get access to the [Cloud console](https://console.eventstore.cloud), where you can provision and manage EventStoreDB clusters, back and up restore your data, establish the connection between EventStoreDB Cloud networks and your own cloud infrastructure.
+As a customer of Event Store Cloud you get access to the [Cloud console](https://console.eventstore.cloud), where you can provision and manage EventStoreDB clusters, back and up restore your data, establish the connection between Event Store Cloud networks and your own cloud infrastructure.
 
 The Cloud console uses the [API](../automation/api.md), which is also available for customers. Using the API, you can execute any operation available in the console, programmatically. We also offer the [Terraform provider](https://github.com/EventStore/terraform-provider-eventstorecloud) and the [CLI tool](https://github.com/EventStore/esc) which is built on top of the same API.
 

--- a/docs/cloud/intro/preview.md
+++ b/docs/cloud/intro/preview.md
@@ -1,14 +1,14 @@
 # Cloud Preview
 
-EventStoreDB Cloud is currently in Preview. On this page we describe what Preview means exactly.
+Event Store Cloud is currently in Preview. On this page we describe what Preview means exactly.
 
 ## Why Preview?
 
-At this stage, EventStoreDB Cloud uses the latest available production release of EventStoreDB. It is important to understand that as part of the Preview our customers use the **production** version of our underlying database product.
+At this stage, Event Store Cloud uses the latest available production release of EventStoreDB. It is important to understand that as part of the Preview our customers use the **production** version of our underlying database product.
 
 The Preview stage only applies to the managed cloud. We consider it production-ready, but it lacks some important features, which we believe are necessary for the generally available (GA) product.
 
-In order to ensure the best customer experience for early adopters of EventStoreDB Cloud, the Preview phase is enabled for everyone but new customers cannot provision paid cloud resources right after creating the account. You, however, can see what cloud providers we support, available instance sizes and prices. When you decide to move on and provision one or more clusters, request us to enable provisioning for you in the Cloud console.
+In order to ensure the best customer experience for early adopters of Event Store Cloud, the Preview phase is enabled for everyone but new customers cannot provision paid cloud resources right after creating the account. You, however, can see what cloud providers we support, available instance sizes and prices. When you decide to move on and provision one or more clusters, request us to enable provisioning for you in the Cloud console.
 
 ## Preview status
 

--- a/docs/cloud/intro/quick-start.md
+++ b/docs/cloud/intro/quick-start.md
@@ -1,6 +1,6 @@
 # Cloud quick start
 
-Follow the steps in this guide to get access to the EventStoreDB Cloud console, provision your first cluster and connect it to your cloud infrastructure.
+Follow the steps in this guide to get access to the Event Store Cloud console, provision your first cluster and connect it to your cloud infrastructure.
 
 ## Get an account
 
@@ -23,7 +23,7 @@ To finalize the sign-up process, you'd need to confirm your email address by cli
 With the new account you can login to the [Cloud console](https://console.eventstore.cloud). From the console you can manage your organisations, users, projects and EventStoreDB clusters.
 
 ::: warning Gated provisioning
-Since EventStoreDB Cloud is currently in preview, you won't be able to create new cloud resources like networks and clusters. Click on the `Request to enable provisioning` link to get provisioning enabled.
+Since Event Store Cloud is currently in preview, you won't be able to create new cloud resources like networks and clusters. Click on the `Request to enable provisioning` link to get provisioning enabled.
 :::
 
 In the console, you first get to the list of organisations that you have access to.
@@ -57,7 +57,7 @@ You can always switch to another organisation by clicking on the selected organi
 Each organisation has its own access control. It includes the list of users, which have access to the organisation, groups, roles, policies and identity providers.
 
 ::: tip Preview functionality is limited
-Some features like roles, policies and identity providers are currently not available in Preview. We will roll out all the access control features during the Preview phase, before EventStoreDB Cloud reaches the GA status.
+Some features like roles, policies and identity providers are currently not available in Preview. We will roll out all the access control features during the Preview phase, before Event Store Cloud reaches the GA status.
 :::
 
 When you create an organisation, you will be the organisation admin by default. To invite more people, click on the `Access control` menu and then switch to `Invitations`. There, you will see the `Invite member` button, which brings the invite screen. You'd need to enter the email address for the new member and also the group, which the invited member gets added to when they accept the invite.
@@ -82,7 +82,7 @@ When you click on a project in the projects list, you get to the project context
 
 Within the project context you can manage project clusters, backups, networks, etc.
 
-By reaching this point, you are now ready to start provisioning cloud resources with EventStoreDB Cloud. Follow one of the available guidelines for your cloud provider:
+By reaching this point, you are now ready to start provisioning cloud resources with Event Store Cloud. Follow one of the available guidelines for your cloud provider:
 
 - [Amazon Web Services (AWS)](../provision/aws)
 - [Google Cloud Platform (GCP)](../provision/gcp)

--- a/docs/cloud/provision/README.md
+++ b/docs/cloud/provision/README.md
@@ -1,10 +1,10 @@
-# EventStoreDB Cloud provisioning
+# Event Store Cloud provisioning
 
-EventStoreDB Cloud allows you to provision EventStoreDB clusters in AWS, GCP, and Azure.
+Event Store Cloud allows you to provision EventStoreDB clusters in AWS, GCP, and Azure.
 
 The provisioning process consists of the following steps:
 
-1. Create a network in EventStoreDB Cloud.
+1. Create a network in Event Store Cloud.
 2. Peer the new network with your own network at the same cloud.
 3. Deploy the EventStoreDB cluster.
 

--- a/docs/cloud/provision/aws/README.md
+++ b/docs/cloud/provision/aws/README.md
@@ -1,9 +1,9 @@
 # Cloud EventStoreDB in AWS
 
-For AWS customers, EventStoreDB Cloud allows provisioning an EventStoreDB cluster in the same cloud. You can create a cluster in the same region to ensure lowest latency.
+For AWS customers, Event Store Cloud allows provisioning an EventStoreDB cluster in the same cloud. You can create a cluster in the same region to ensure lowest latency.
 
 Pre-requisites:
-- You are a Preview customer of EventStoreDB Cloud
+- You are a Preview customer of Event Store Cloud
 - You have an organisation registered in Cloud console
 - You can login to the Cloud console as admin
 - Your organisation has at least one project
@@ -11,13 +11,13 @@ Pre-requisites:
 - You have access to create AWS resources in the AWS account of your organisation
 
 The provisioning process consists of three steps:
-1. Create a network in EventStoreDB Cloud
+1. Create a network in Event Store Cloud
 2. Provision the EventStoreDB instance or cluster
 3. Peer the new network with your own AWS network
 
 ## Create a network
 
-In the EventStoreDB Cloud console, go to the [project context](../../intro/quick-start.md#projects) and switch to `Networks`. Then, click on the `New network` button.
+In the Event Store Cloud console, go to the [project context](../../intro/quick-start.md#projects) and switch to `Networks`. Then, click on the `New network` button.
  
  Make sure to fill out the required information:
  - Network name
@@ -29,7 +29,7 @@ In the EventStoreDB Cloud console, go to the [project context](../../intro/quick
 ![Create AWS network](./images/aws-create-network.png)
 :::
  
- In order to establish a connection between the cluster network and your own cloud network, you'd need to peer them. Currently, EventStoreDB Cloud only supports peering within the same region. Therefore, ensure that you choose the same region as your own cloud network.
+ In order to establish a connection between the cluster network and your own cloud network, you'd need to peer them. Currently, Event Store Cloud only supports peering within the same region. Therefore, ensure that you choose the same region as your own cloud network.
  
  The network address range should not overlap with the address range of other networks in the same region and with your own AWS network, which you will be peering with. As any other cloud network, the CIDR block needs to be within the range specified by RFC1918.
  
@@ -79,7 +79,7 @@ Finally, when you click on `Create cluster`, the provisioning process starts and
 
 ## Network peering
 
-When the cluster provisioning process finishes, you get a new cluster (or single instance), which is connected to the network created in the first step. You won't be able to connect to the cluster since the network is not exposed to the Internet. In order to get access to the network and consequently to all the clusters in that network, you'd need to peer the EventStoreDB Cloud network to your own AWS network. Normally, your AWS network would be also accessible by applications, which you want to connect to the new cloud EventStoreDB cluster.
+When the cluster provisioning process finishes, you get a new cluster (or single instance), which is connected to the network created in the first step. You won't be able to connect to the cluster since the network is not exposed to the Internet. In order to get access to the network and consequently to all the clusters in that network, you'd need to peer the Event Store Cloud network to your own AWS network. Normally, your AWS network would be also accessible by applications, which you want to connect to the new cloud EventStoreDB cluster.
 
 ::: warning Peering limitations
 Currently, you can peer one Event Store Cloud network with only one AWS VPC on your account. We expect to lift this limitation in the future.
@@ -91,7 +91,7 @@ For this example, we'll use a VPC in AWS in the same region (`eu-central-1`).
 ![AWS VPC details](./images/aws-vpc.png)
 :::
 
-The network page provide us enough details to start the peering process. In EventStoreDB Cloud console, while in the same project context as the new network and cluster, click on `Peering` under the `Project` menu, then click on `New peering`.
+The network page provide us enough details to start the peering process. In Event Store Cloud console, while in the same project context as the new network and cluster, click on `Peering` under the `Project` menu, then click on `New peering`.
 
 Then, give the new peering a name and select the network created earlier.
 
@@ -122,11 +122,11 @@ When the peering is initiated, get back to AWS console and navigate to `Virtual 
 ![Incoming peering request](./images/aws-peering-3.png)
 :::
 
-Select the pending peering and click on `Actions` - `Accept request`. Validate the request details and ensure that all the details match the peering, which you can see in EventStoreDB Cloud console. If everything is correct, click on the `Yes, Accept` button. After you get a confirmation, you will see the peering in AWS console to become `Active`. Now, you can get back to EventStoreDB Cloud console, refresh the peering list to ensure that the pending record also changed its status to `Active`.
+Select the pending peering and click on `Actions` - `Accept request`. Validate the request details and ensure that all the details match the peering, which you can see in Event Store Cloud console. If everything is correct, click on the `Yes, Accept` button. After you get a confirmation, you will see the peering in AWS console to become `Active`. Now, you can get back to Event Store Cloud console, refresh the peering list to ensure that the pending record also changed its status to `Active`.
 
-Now, although both networks are now connected, AWS doesn't create proper routes automatically. To finish the setup, open the AWS VPC details and click on the route table link, then on the `Routes` tab. There you'll see that the network has no route to the EventStoreDB Cloud network, so you need to create one.
+Now, although both networks are now connected, AWS doesn't create proper routes automatically. To finish the setup, open the AWS VPC details and click on the route table link, then on the `Routes` tab. There you'll see that the network has no route to the Event Store Cloud network, so you need to create one.
 
-Click on `Edit routes` and then `Add route`. In the `Destination`, enter the CIDR of the EventStoreDB Cloud network. For the `Target`, choose the `Peering Connection` option.
+Click on `Edit routes` and then `Add route`. In the `Destination`, enter the CIDR of the Event Store Cloud network. For the `Target`, choose the `Peering Connection` option.
 
 ::: card
 ![AWS route](./images/aws-network-route.png)

--- a/docs/cloud/provision/azure/README.md
+++ b/docs/cloud/provision/azure/README.md
@@ -1,13 +1,13 @@
 # Cloud EventStoreDB in Azure
 
-For Microsoft Azure customers, EventStoreDB Cloud allows provisioning an EventStoreDB cluster in the same cloud. You can create a cluster in the same region to ensure lowest latency.
+For Microsoft Azure customers, Event Store Cloud allows provisioning an EventStoreDB cluster in the same cloud. You can create a cluster in the same region to ensure lowest latency.
 
 ::: warning Azure considerations
 Microsoft Azure has a few differences that you need to consider when using Event Store Cloud with Azure. We listed all currently known limitations on a [separate page](./considerations.md). Please ensure you are aware of it before starting to use EventStoreDB in Azure.
 :::
 
 Pre-requisites:
-- You are a Preview customer of EventStoreDB Cloud
+- You are a Preview customer of Event Store Cloud
 - You have an organisation registered in Cloud console
 - You can login to the Cloud console as admin
 - Your organisation has at least one project
@@ -15,13 +15,13 @@ Pre-requisites:
 - You have access to create Azure resources in the Azure account of your organisation
 
 The provisioning process consists of three steps:
-1. Create a network in EventStoreDB Cloud
+1. Create a network in Event Store Cloud
 2. Provision the EventStoreDB instance or cluster
 3. Peer the new network with your own Azure network
 
 ## Create a network
 
-In the EventStoreDB Cloud console, go to the [project context](../../intro/quick-start.md#projects) and switch to `Networks`. Then, click on the `New network` button.
+In the Event Store Cloud console, go to the [project context](../../intro/quick-start.md#projects) and switch to `Networks`. Then, click on the `New network` button.
  
  Make sure to fill out the required information:
  - Network name
@@ -33,7 +33,7 @@ In the EventStoreDB Cloud console, go to the [project context](../../intro/quick
 ![Create Azure network](./images/azure-create-network.png)
 :::
  
- In order to establish a connection between the cluster network and your own cloud network, you'd need to peer them. Currently, EventStoreDB Cloud only supports peering within the same region. Therefore, ensure that you choose the same region as your own cloud network.
+ In order to establish a connection between the cluster network and your own cloud network, you'd need to peer them. Currently, Event Store Cloud only supports peering within the same region. Therefore, ensure that you choose the same region as your own cloud network.
  
  The network address range should not overlap with the address range of other networks in the same region and with your own Azure network, which you will be peering with. As any other cloud network, the CIDR block needs to be within the range specified by RFC1918.
  
@@ -83,7 +83,7 @@ Finally, when you click on `Create cluster`, the provisioning process starts and
 
 ## Network peering
 
-When the cluster provisioning process finishes, you get a new cluster (or single node), which is connected to the network created in the first step. You won't be able to connect to the cluster since the network is not exposed to the Internet. In order to get access to the network and consequently to all the clusters in that network, you'd need to peer the EventStoreDB Cloud network to your own Azure network. Normally, your Azure network would be also accessible by applications, which you want to connect to the new cloud EventStoreDB cluster.
+When the cluster provisioning process finishes, you get a new cluster (or single node), which is connected to the network created in the first step. You won't be able to connect to the cluster since the network is not exposed to the Internet. In order to get access to the network and consequently to all the clusters in that network, you'd need to peer the Event Store Cloud network to your own Azure network. Normally, your Azure network would be also accessible by applications, which you want to connect to the new cloud EventStoreDB cluster.
 
 ::: warning Peering limitations
 Currently, you can peer one Event Store Cloud network with only one Azure network on your account. We expect to lift this limitation in the future.
@@ -91,7 +91,7 @@ Currently, you can peer one Event Store Cloud network with only one Azure networ
 
 For this example, we'll use an Azure network the same region (UK South).
 
-In EventStoreDB Cloud console, while in the same project context as the new network and cluster, click on `Peering` under the `Project` menu, then click on `New peering`.
+In Event Store Cloud console, while in the same project context as the new network and cluster, click on `Peering` under the `Project` menu, then click on `New peering`.
 
 Then, give the new peering a name and select the network created earlier.
 

--- a/docs/cloud/provision/azure/considerations.md
+++ b/docs/cloud/provision/azure/considerations.md
@@ -8,7 +8,7 @@ When creating a peering link, Azure requires the user to configure a security pr
 
 ## Disk resize
 
-Currently, it is impossible to expand disks on EventStoreDB cloud nodes provisioned to Azure. We plan to provide this feature at a later date, but as there is no native support within Azure, implementing this requires more planning and thought on our part.
+Currently, it is impossible to expand disks on Event Store Cloud nodes provisioned to Azure. We plan to provide this feature at a later date, but as there is no native support within Azure, implementing this requires more planning and thought on our part.
 
 There are positive ways around this, and we advise you to choose the disk size accordingly from the start, so the volume size will accommodate the growth of your data over time. You can also backup an existing cluster and restore the data to a new cluster with larger disks.
 

--- a/docs/cloud/provision/gcp/README.md
+++ b/docs/cloud/provision/gcp/README.md
@@ -1,9 +1,9 @@
 # Cloud EventStoreDB in GCP
 
-For Google Cloud customers, EventStoreDB Cloud allows provisioning an EventStoreDB cluster in the same cloud. You can create a cluster in the same region to ensure lowest latency.
+For Google Cloud customers, Event Store Cloud allows provisioning an EventStoreDB cluster in the same cloud. You can create a cluster in the same region to ensure lowest latency.
 
 Pre-requisites:
-- You are a Preview customer of EventStoreDB Cloud
+- You are a Preview customer of Event Store Cloud
 - You have an organisation registered in Cloud console
 - You can login to the Cloud console as admin
 - Your organisation has at least one project
@@ -11,13 +11,13 @@ Pre-requisites:
 - You have access to create Google Cloud resources in the GCP project of your organisation
 
 The provisioning process consists of three steps:
-1. Create a network in EventStoreDB Cloud
+1. Create a network in Event Store Cloud
 2. Provision the EventStoreDB instance or cluster
 3. Peer the new network with your own network in GCP
 
 ## Create a network
 
-In the EventStoreDB Cloud console, go to the [project context](../../quick-start.md#projects) and switch to `Networks`. Then, click on the `New network` button.
+In the Event Store Cloud console, go to the [project context](../../quick-start.md#projects) and switch to `Networks`. Then, click on the `New network` button.
  
  Make sure to fill out the required information:
  - Network name
@@ -29,7 +29,7 @@ In the EventStoreDB Cloud console, go to the [project context](../../quick-start
 ![Create GCP network](./images/gcp-create-network.png)
 :::
  
- In order to establish a connection between the cluster network and your own cloud network, you'd need to peer them. Currently, EventStoreDB Cloud only supports peering within the same region. Therefore, ensure that you choose the same region as your own cloud network.
+ In order to establish a connection between the cluster network and your own cloud network, you'd need to peer them. Currently, Event Store Cloud only supports peering within the same region. Therefore, ensure that you choose the same region as your own cloud network.
  
  The network address range should not overlap with the address range of other networks in the same region and with your own GCP network, which you will be peering with. As any other cloud network, the CIDR block needs to be within the range specified by RFC1918.
  
@@ -79,7 +79,7 @@ Finally, when you click on `Create cluster`, the provisioning process starts and
 
 ## Network peering
 
-When the cluster provisioning process finishes, you get a new cluster (or single instance), which is connected to the network created in the first step. You won't be able to connect to the cluster since the network is not exposed to the Internet. In order to get access to the network and consequently to all the clusters in that network, you'd need to peer the EventStoreDB Cloud network to your own GCP VPC network. Normally, your GCP VPC network would be also accessible by applications, which you want to connect to the new cloud EventStoreDB cluster.
+When the cluster provisioning process finishes, you get a new cluster (or single instance), which is connected to the network created in the first step. You won't be able to connect to the cluster since the network is not exposed to the Internet. In order to get access to the network and consequently to all the clusters in that network, you'd need to peer the Event Store Cloud network to your own GCP VPC network. Normally, your GCP VPC network would be also accessible by applications, which you want to connect to the new cloud EventStoreDB cluster.
 
 ::: warning Peering limitations
 Currently, you can peer one Event Store Cloud network with only one GCP network on your account. We expect to lift this limitation in the future.
@@ -91,9 +91,9 @@ For this example, we'll use a VPC network in GCP in the same region (`europe-wes
 ![GCP VPC details](./images/gpc-vpc-details.png)
 :::
 
-Notice that the VPC has one subnet in the same region as the EventStoreDB Cloud network provisioned earlier.
+Notice that the VPC has one subnet in the same region as the Event Store Cloud network provisioned earlier.
 
-The network page provide us enough details to start the peering process. In EventStoreDB Cloud console, while in the same project context as the new network and cluster, click on `Peering` under the `Project` menu, then click on `New peering`.
+The network page provide us enough details to start the peering process. In Event Store Cloud console, while in the same project context as the new network and cluster, click on `Peering` under the `Project` menu, then click on `New peering`.
 
 Then, give the new peering a name and select the network created earlier. You'd need to fill out the remaining fields, using the information from GCP VPC.
 
@@ -120,7 +120,7 @@ The information on the peering details screen provides some essential informatio
 
 When the peering is initiated, get back to Google Cloud console and navigate to `VPC network peering`. There, click `Create connection` and then `Continue`. Give new peering a name and choose the network on GCP side. Next, fill out the remaining values using the initiated peering details:
 
-| EventStoreDB Cloud | GCP connection peering |
+| Event Store Cloud | GCP connection peering |
 | :---------------- | :--------------------- |
 | Peer Project ID | Project ID |
 | Peer Network Name | VPC network name |
@@ -133,7 +133,7 @@ Here is how our example GCP peering form would look like:
 ![Incoming peering request](./images/gcp-peering-3.png)
 :::
 
-Click the `Create` button and when in the `VPC network peering` list, click `Refresh` until the peering status changes to `Active`. The peering status in EventStoreDB Cloud console should also change to `Active`.
+Click the `Create` button and when in the `VPC network peering` list, click `Refresh` until the peering status changes to `Active`. The peering status in Event Store Cloud console should also change to `Active`.
 
 ::: tip Peering issues
 You might see the peering request getting stuck. There are several reasons for this to happen, like your cloud account quota or overlapping CIDR blocks. You can find all the necessary diagnostics in the `Event Console` in Event Store Cloud. 

--- a/docs/cloud/use/README.md
+++ b/docs/cloud/use/README.md
@@ -6,17 +6,17 @@ Each major cloud provider implements the concept of a Virtual Private Cloud (VPC
 
 Normally, organisations build internal practices in regards to VPCs isolation and access level. In particular, you would expect that some or all VPCs are available for direct access from local networks on-premises, for developers to be able to access cloud resources. Cloud providers let their customers to connect on-premises networks to VPCs using site-to-site VPN connections. In addition, cloud customers often set up virtual private gateways to allow point-to-site VPN connections for their remote users.
 
-EventStoreDB Cloud deploys EventStoreDB clusters on a project-level VPC (network). By peering that network with your own VPC at the same cloud provider, you get access to the EventStoreDB cluster provisioned and managed by EventStoreDB Cloud. Normally, your Ops engineers would be able to configure the routing and allow connecting to EventStoreDB clusters in the cloud.
+Event Store Cloud deploys EventStoreDB clusters on a project-level VPC (network). By peering that network with your own VPC at the same cloud provider, you get access to the EventStoreDB cluster provisioned and managed by Event Store Cloud. Normally, your Ops engineers would be able to configure the routing and allow connecting to EventStoreDB clusters in the cloud.
 
 ## TailScale
 
-Another options to connect to the cloud cluster is to use a third-party VPN offering, which might be easier to use. One example would [TailScale](https://tailscale.com), which is a [WireGuard®](https://www.wireguard.com/) based mesh VPN. In addition to the basic functionality of connecting devices in a mesh network, TailGate also allows connecting a subnet to the private VPN. For that, you'd need to provision a VM in the cloud, which is connected to the network peered with EventStoreDB Cloud network. Since that machine would be able to access the EventStoreDB cluster, by configuring the TailScale [subnet routing](https://tailscale.com/kb/1019/subnets) you will also make the cluster accessible for all users of your TailScale network.
+Another options to connect to the cloud cluster is to use a third-party VPN offering, which might be easier to use. One example would [TailScale](https://tailscale.com), which is a [WireGuard®](https://www.wireguard.com/) based mesh VPN. In addition to the basic functionality of connecting devices in a mesh network, TailGate also allows connecting a subnet to the private VPN. For that, you'd need to provision a VM in the cloud, which is connected to the network peered with Event Store Cloud network. Since that machine would be able to access the EventStoreDB cluster, by configuring the TailScale [subnet routing](https://tailscale.com/kb/1019/subnets) you will also make the cluster accessible for all users of your TailScale network.
 
 Check our [Tailscale guide](tailscale.md) for detailed instructions.
 
 ## Cluster connection
 
-EventStoreDB Cloud unconditionally provisions secure EventStoreDB clusters with both TLS for TCP and SSL for HTTP and gRPC enabled. This configuration cannot be changed.
+Event Store Cloud unconditionally provisions secure EventStoreDB clusters with both TLS for TCP and SSL for HTTP and gRPC enabled. This configuration cannot be changed.
 
 Cloud clusters use SSL certificates signed by the trusted public certificate authority and therefore you won't need to do any additional work that is usually associated with self-signed certificates.
 

--- a/docs/cloud/use/tailscale.md
+++ b/docs/cloud/use/tailscale.md
@@ -1,6 +1,6 @@
 # Connect with Tailscale
 
-In many organisations which work with the cloud, you can find the connection between the cloud networks and your local network already established using a Virtual Private Gateway or Site-to-Site VPN connection. However, if you're starting on the side and want to keep things simple, you can use Tailscale to connect to the EventStoreDB Cloud cluster.
+In many organisations which work with the cloud, you can find the connection between the cloud networks and your local network already established using a Virtual Private Gateway or Site-to-Site VPN connection. However, if you're starting on the side and want to keep things simple, you can use Tailscale to connect to the Event Store Cloud cluster.
 
 ## What is Tailscale?
 
@@ -16,12 +16,12 @@ Follow the [installation instructions](https://tailscale.com/kb/1017/install) to
 
 ## Provision the cloud VM
 
-Next, you need to create a small VM in the cloud, connected to the VPC with the EventStoreDB Cloud.
+Next, you need to create a small VM in the cloud, connected to the VPC with the Event Store Cloud.
 
 You can choose the smallest available instance size, like `t4g.nano` in AWS, `f1.micro` in GCP, or `Standard B1ls` in Azure. For this guide we use Ubuntu 20.04 LTS image (18.04 LTS in Azure).
 
 When creating the VM, make sure you:
-- Connect the default network interface to the VPC peered with EventStoreDB Cloud
+- Connect the default network interface to the VPC peered with Event Store Cloud
 - Enable public IP if you want to connect to the VM from your local machine
 - GCP: enable _IP Forwarding_ on the default NIC
 - AWS: disable _Source / destination checking_
@@ -45,7 +45,7 @@ On the new VM instance page and scroll down to the `Management, security, disks,
 ::::
 :::::
 
-Remember to create the VM instance in the same region as the VPC, which is peered with EventStoreDB Cloud.
+Remember to create the VM instance in the same region as the VPC, which is peered with Event Store Cloud.
 
 ## Set up Tailscale subnet routing
 
@@ -55,7 +55,7 @@ After logging in, install the Tailscale client for the Linux distribution used f
 
 When the initial steps are completed, you should be able to ping the cloud VM using its internal IP address from your local machine.
 
-Next, visit the EventStoreDB Cloud console and open the peering page. There you will find the peering you created when following the provisioning guidelines. Write down the details from the `Local Address` and `Remote Address` fields.
+Next, visit the Event Store Cloud console and open the peering page. There you will find the peering you created when following the provisioning guidelines. Write down the details from the `Local Address` and `Remote Address` fields.
 
 For this example we will use the following peering details:
 ::: card
@@ -79,7 +79,7 @@ In the example above we used both address spaces of both sides of the peering as
 
 Next, visit your Tailscale Admin Console, find the cloud VM in the list and use the three dots popup menu to enable subnet routing and disable key expiry.
 
-Now, visit the EventStoreDB Cloud console, switch to the Clusters page and choose the EventStoreDB cluster. In the cluster details select the `Addresses` tab and click on the UI link. You should then get the EventStoreDB Admin UI opened in your local machine browser.
+Now, visit the Event Store Cloud console, switch to the Clusters page and choose the EventStoreDB cluster. In the cluster details select the `Addresses` tab and click on the UI link. You should then get the EventStoreDB Admin UI opened in your local machine browser.
 
 This is how the network looks like when using Tailscale: 
 
@@ -91,4 +91,4 @@ This is how the network looks like when using Tailscale:
 
 ## Future plans
 
-Soon, we want to add out-of-the-box Tailscale network peering, which will create a nano-VM inside EventStoreDB Cloud and set up routing to your Tailscale account automatically.
+Soon, we want to add out-of-the-box Tailscale network peering, which will create a nano-VM inside Event Store Cloud and set up routing to your Tailscale account automatically.


### PR DESCRIPTION
See also: https://github.com/EventStore/esc/pull/60.