### PR TITLE
Added Algolia Search support

### DIFF
--- a/.algolia/config.json
+++ b/.algolia/config.json
@@ -4,14 +4,26 @@
   "selectors": {
     "lvl0": ".sidebar h3.version",
     "lvl1": {
-        "selector": ".sidebar-heading.open span",
-        "global": true,
-        "default_value": "Documentation"
-      },
-    "lvl2": ".content__default h1",
-    "lvl3": ".content__default h2",
-    "lvl4": ".content__default h3",
-    "lvl5": ".content__default h4",
+      "selector": ".sidebar-heading.open span",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl2": {
+      "selector": ".content__default h1",
+      "strip_chars": "#"
+    },
+    "lvl3": {
+      "selector": ".content__default h2",
+      "strip_chars": "#"
+    },
+    "lvl4": {
+      "selector": ".content__default h3",
+      "strip_chars": "#"
+    },
+    "lvl5": {
+      "selector": ".content__default h4",
+      "strip_chars": "#"
+    },
     "text": ".content__default p, .content__default li",
     "lang": {
       "selector": "/html/@lang",

--- a/.algolia/config.json
+++ b/.algolia/config.json
@@ -1,0 +1,27 @@
+{
+  "index_name": "scraper-test",
+  "start_urls": ["https://developers.eventstore.com/"],
+  "selectors": {
+    "lvl0": ".sidebar h3.version",
+    "lvl1": {
+        "selector": ".sidebar-heading.open span",
+        "global": true,
+        "default_value": "Documentation"
+      },
+    "lvl2": ".content__default h1",
+    "lvl3": ".content__default h2",
+    "lvl4": ".content__default h3",
+    "lvl5": ".content__default h4",
+    "text": ".content__default p, .content__default li",
+    "lang": {
+      "selector": "/html/@lang",
+      "type": "xpath",
+      "global": true
+    }
+  },
+  "custom_settings": {
+    "attributesForFaceting": [
+      "lang"
+    ]
+  }
+}

--- a/.algolia/scrape.sh
+++ b/.algolia/scrape.sh
@@ -1,0 +1,9 @@
+if [ -f .env ]; then
+    export $(xargs < .env)
+fi
+
+docker run \
+    -e APPLICATION_ID \
+    -e API_KEY \
+    -e CONFIG="$(cat config.json | jq '.start_urls=[env.ALGOLIA_SITE_URL]' | jq '.index_name=env.ALGOLIA_INDEX_NAME' | jq -r tostring)" \
+    algolia/docsearch-scraper:v1.13.0

--- a/.algolia/scrape.sh
+++ b/.algolia/scrape.sh
@@ -3,7 +3,7 @@ if [ -f .env ]; then
 fi
 
 docker run \
-    -e APPLICATION_ID \
-    -e API_KEY \
+    -e APPLICATION_ID=$(printenv ALGOLIA_APPLICATION_ID) \
+    -e API_KEY=$(printenv ALGOLIA_WRITE_API_KEY) \
     -e CONFIG="$(cat config.json | jq '.start_urls=[env.ALGOLIA_SITE_URL]' | jq '.index_name=env.ALGOLIA_INDEX_NAME' | jq -r tostring)" \
     algolia/docsearch-scraper:v1.13.0

--- a/.github/workflows/algolia-scraper.yml
+++ b/.github/workflows/algolia-scraper.yml
@@ -1,0 +1,20 @@
+name: algolia-scraper
+on: push
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out code 🛎
+        uses: actions/checkout@v2
+      # when scraping the site, inject secrets as environment variables
+      # then pass their values into the Docker container using "-e" syntax
+      # and inject config.json contents as another variable
+      - name: scrape the site 🧽
+        env:
+          APPLICATION_ID: ${{ secrets.ALGOLIA_APPLICATION_ID }}
+          API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+        run: |
+          docker run \
+          -e APPLICATION_ID -e API_KEY \
+          -e CONFIG="$(cat .algolia/config.json | jq -r tostring)" \
+          algolia/docsearch-scraper:v1.13.0

--- a/.github/workflows/algolia-scraper.yml
+++ b/.github/workflows/algolia-scraper.yml
@@ -1,5 +1,8 @@
 name: algolia-scraper
 on:
+  push:
+    branches:
+      - master
   check_suite:
     types: [completed]
   workflow_dispatch:

--- a/.github/workflows/algolia-scraper.yml
+++ b/.github/workflows/algolia-scraper.yml
@@ -1,5 +1,8 @@
 name: algolia-scraper
-on: push
+on:
+  check_suite:
+    types: [completed]
+  workflow_dispatch:
 jobs:
   scrape:
     runs-on: ubuntu-latest

--- a/.github/workflows/algolia-scraper.yml
+++ b/.github/workflows/algolia-scraper.yml
@@ -11,8 +11,8 @@ jobs:
       # and inject config.json contents as another variable
       - name: scrape the site 🧽
         env:
-          APPLICATION_ID: ${{ secrets.ALGOLIA_APPLICATION_ID }}
-          API_KEY: ${{ secrets.ALGOLIA_WRITE_API_KEY }}
+          ALGOLIA_APPLICATION_ID: ${{ secrets.ALGOLIA_APPLICATION_ID }}
+          ALGOLIA_WRITE_API_KEY: ${{ secrets.ALGOLIA_WRITE_API_KEY }}
           ALGOLIA_SITE_URL: ${{ secrets.ALGOLIA_SITE_URL }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
         run: |

--- a/.github/workflows/algolia-scraper.yml
+++ b/.github/workflows/algolia-scraper.yml
@@ -12,9 +12,10 @@ jobs:
       - name: scrape the site 🧽
         env:
           APPLICATION_ID: ${{ secrets.ALGOLIA_APPLICATION_ID }}
-          API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          API_KEY: ${{ secrets.ALGOLIA_WRITE_API_KEY }}
+          ALGOLIA_SITE_URL: ${{ secrets.ALGOLIA_SITE_URL }}
+          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
         run: |
-          docker run \
-          -e APPLICATION_ID -e API_KEY \
-          -e CONFIG="$(cat .algolia/config.json | jq -r tostring)" \
-          algolia/docsearch-scraper:v1.13.0
+          cd .algolia
+          touch .env
+          ./scrape.sh

--- a/.gitignore
+++ b/.gitignore
@@ -340,3 +340,4 @@ generated-versions.json
 *.lock.hcl
 *.tfstate
 *.tfstate.backup
+.algolia/.env

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Documentation is written using [VuePress](https://vuepress.vuejs.org/).
 2. Run `yarn install`
 3. Run `yarn docs:dev`
 
+### Running Algolia search locally
+
+To run Algolia search locally, you need to set the following environment variables:
+- `ALGOLIA_API_KEY`
+- `ALGOLIA_APP_ID`
+- `ALGOLIA_INDEX_NAME`
+with proper values taken from the Algolia configuration.
+
 ### Adding new programming language snippets
 
 To add new language snippet it's needed to add import of [Prism.JS](https://prismjs.com/) plugin to [VuePress plugins config](docs/.vuepress/enhanceApp.js), e.g.:

--- a/README.md
+++ b/README.md
@@ -37,26 +37,19 @@ Documentation is written using [VuePress](https://vuepress.vuejs.org/).
 
 Documentation is using Algolia for indexing and searching through the contents.
 
-#### Testing search locally
-
-To run Algolia search locally, you need to set the following environment variables:
-- `ALGOLIA_API_KEY`
-- `ALGOLIA_APP_ID`
-- `ALGOLIA_INDEX_NAME`
-with proper values taken from the Algolia configuration.
-
-### Scraping data locally
-
-Create [.algolia\.env](.algolia/.env) file with contents based on the Algolia configuration:
+To run Algolia search locally, create [.algolia\.env](.algolia/.env) file filled with contents based on the Algolia configuration:
 
 ```bash
-APPLICATION_ID=
-API_KEY=
+ALGOLIA_APPLICATION_ID=
+ALGOLIA_WRITE_API_KEY=
 ALGOLIA_SITE_URL=
 ALGOLIA_INDEX_NAME=
+ALGOLIA_SEARCH_API_KEY=
 ```
 
 _**Note:** Make sure that you saved it with LF eol characters._
+
+### Scraping data locally
 
 Go to the [.algolia](.algolia) folder and run the [scrape.sh](.algolia/scrape.sh) script.
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,32 @@ Documentation is written using [VuePress](https://vuepress.vuejs.org/).
 2. Run `yarn install`
 3. Run `yarn docs:dev`
 
-### Running Algolia search locally
+### Algolia Search
+
+Documentation is using Algolia for indexing and searching through the contents.
+
+#### Testing search locally
 
 To run Algolia search locally, you need to set the following environment variables:
 - `ALGOLIA_API_KEY`
 - `ALGOLIA_APP_ID`
 - `ALGOLIA_INDEX_NAME`
 with proper values taken from the Algolia configuration.
+
+### Scraping data locally
+
+Create [.algolia\.env](.algolia/.env) file with contents based on the Algolia configuration:
+
+```bash
+APPLICATION_ID=
+API_KEY=
+ALGOLIA_SITE_URL=
+ALGOLIA_INDEX_NAME=
+```
+
+_**Note:** Make sure that you saved it with LF eol characters._
+
+Go to the [.algolia](.algolia) folder and run the [scrape.sh](.algolia/scrape.sh) script.
 
 ### Adding new programming language snippets
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -179,7 +179,7 @@ module.exports = {
         algolia: {
             apiKey: process.env.ALGOLIA_API_KEY,
             indexName: process.env.ALGOLIA_INDEX_NAME,
-            appId: process.env.ALGOLIA_APP_ID,
+            appId: process.env.ALGOLIA_APPLICATION_ID,
             hitsPerPage: 10,
           }
     },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,5 +1,7 @@
 const containers = require("./lib/containers.js");
 const versioning = require("./lib/versioning.js");
+const path = require('path');
+require('dotenv').config({path: path.join(__dirname, '..', '..', '.algolia', '.env')})
 
 versioning.load();
 
@@ -177,11 +179,11 @@ module.exports = {
             ]
         },
         algolia: {
-            apiKey: process.env.ALGOLIA_API_KEY,
+            apiKey: process.env.ALGOLIA_SEARCH_API_KEY,
             indexName: process.env.ALGOLIA_INDEX_NAME,
-            appId: process.env.ALGOLIA_APPLICATION_ID,
+            appId: process.env.APPLICATION_ID,
             hitsPerPage: 10,
-          }
+        }
     },
     markdown:        {
         extendMarkdown: md => {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -181,7 +181,7 @@ module.exports = {
         algolia: {
             apiKey: process.env.ALGOLIA_SEARCH_API_KEY,
             indexName: process.env.ALGOLIA_INDEX_NAME,
-            appId: process.env.APPLICATION_ID,
+            appId: process.env.ALGOLIA_APPLICATION_ID,
             hitsPerPage: 10,
         }
     },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -175,7 +175,13 @@ module.exports = {
                 }
                 
             ]
-        }
+        },
+        algolia: {
+            apiKey: process.env.ALGOLIA_API_KEY,
+            indexName: process.env.ALGOLIA_INDEX_NAME,
+            appId: process.env.ALGOLIA_APP_ID,
+            hitsPerPage: 10,
+          }
     },
     markdown:        {
         extendMarkdown: md => {

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -81,3 +81,24 @@ ul.code-language-switcher
 .el-radio__input.is-checked+.el-radio__label
   color: $accentColor
 
+.algolia-docsearch-suggestion--category-header
+  background: #5ab552 !important
+
+.algolia-docsearch-suggestion--subcategory-column
+  background: #EEF6FE !important
+
+.ds-dropdown-menu, .algolia-docsearch-suggestion--subcategory-column
+  border-color: #EEEEEE !important
+
+.algolia-docsearch-suggestion--highlight
+  background-color: #FFFFFF !important
+  color: #5AB552 !important 
+
+.algolia-docsearch-suggestion--content:hover, .algolia-docsearch-suggestion--content:active
+  background-color: #d6ecd4 !important
+
+.ds-dataset-1
+  line-height: 1.2 !important
+
+.algolia-docsearch-suggestion--title
+  margin-bottom: 5px !important

--- a/docs/.vuepress/theme/components/Version.vue
+++ b/docs/.vuepress/theme/components/Version.vue
@@ -1,5 +1,5 @@
 <template>
-  <h3 class="version" v-if="hasVersion">{{ version }}</h3>
+  <h3 class="version" v-if="hasVersion || hasChildrenTitle">{{ version }}</h3>
 </template>
 
 <script>
@@ -10,11 +10,24 @@ export default {
 
   computed: {
     hasVersion() {
-      return this.sidebarItem !== undefined && this.sidebarItem.group !== undefined;
+      return this.sidebarItem !== undefined && (this.sidebarItem.group !== undefined || (this.sidebarItem.children !== undefined && this.sidebarItem.children.length > 0));
+    },
+    hasChildrenTitle() {
+      return this.sidebarItem !== undefined && this.sidebarItem.children !== undefined && this.sidebarItem.children.length > 0 && this.sidebarItem.children[0].title;
     },
     version() {
-      const version = this.sidebarItem !== undefined ? `v${this.sidebarItem.version}` : "";
-      return `${this.sidebarItem.group} ${version}`;
+      if (this.sidebarItem === undefined || (!this.sidebarItem.group && !this.sidebarItem.children)) {
+        return "";
+      }
+      
+      var group = this.sidebarItem.group;
+
+      if (group) {
+        const version = this.sidebarItem.version ? `v${this.sidebarItem.version}` : "";
+        return `${this.sidebarItem.group} ${version}`
+      }
+
+      return this.sidebarItem.children[0].title;
     }
   }
 }

--- a/docs/clients/dotnet/versions.json
+++ b/docs/clients/dotnet/versions.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "dotnet-client",
-    "group": ".NET SDK",
+    "group": "TCP SDK",
     "basePath": "clients/dotnet",
     "versions": [
       {

--- a/import/import-client-docs.js
+++ b/import/import-client-docs.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const fsExtra = require('fs-extra')
+const fsExtra = require('fs-extra');
 const path = require('path');
 const simpleGit = require('simple-git');
 const git = simpleGit();

--- a/package.json
+++ b/package.json
@@ -7,23 +7,24 @@
     "esm": "^3.0.0",
     "fs-extra": "^9.0.1",
     "markdown-it-container": "^3.0.0",
+    "simple-git": "^2.31.0",
     "swagger-markdown": "^1.2.0",
     "vuepress": "^1.8.0",
     "vuepress-plugin-check-md": "^0.0.2",
     "vuepress-plugin-element-tabs": "^0.2.8",
-    "webpack-shell-plugin": "^0.5.0",
-    "simple-git": "^2.31.0"
+    "webpack-shell-plugin": "^0.5.0"
   },
   "dependencies": {
+    "@auth0/auth0-spa-js": "^1.13.3",
     "axios": "^0.21.1",
+    "dotenv": "^8.2.0",
     "element-ui": "^2.15.0",
     "markdown-it": "^12.0.4",
     "markdown-it-include": "^2.0.0",
     "prismjs": "^1.23.0",
     "vue-prism-component": "^1.2.0",
     "vuepress-plugin-one-click-copy": "^1.0.2",
-    "vuex": "^3.6.0",
-    "@auth0/auth0-spa-js": "^1.13.3"
+    "vuex": "^3.6.0"
   },
   "resolutions": {
     "watchpack": "1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3238,6 +3238,11 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
Added initial Algolia Search changes:
- configuration for running and scrapping both for local and CI/CD ,
- renamed TCP client title,
- updated the version field to show the title from the first item to have proper scrapping in gRPC and Cloud,
- customised styling of the VuePress Algolia.

_**Note:** I'm not sure if the `check_suite` trigger will work on the main branch (so trigger scraping pipeline after Netlify deployed site). In theory it's only triggered there so I cannot verify that on a feature branch. For that reason, I added a trigger on push and manual config. Some additional PR might be needed for that._

Fixes #174 