### PR TITLE
Removed link to v5 docs from the main page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,6 @@
 home: true
 heroText: EventStoreDB Documentation
 tagline: The stream database built for Event Sourcing
-extraText: Click here for EventStoreDB v5 docs
-extraLink: /v5/
 actions:
 - text: Database server →
   link: /latest.html


### PR DESCRIPTION
Per https://eventstore.freshdesk.com/a/tickets/109621