### PR TITLE
Fixed HTTP docs sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,7 +328,6 @@ tools
 exclusive.lck
 *.dll
 *.exe
-.vscode
 version.txt
 /public/
 generated

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+        "type": "node",
+        "request": "launch",
+        "name": "Debug VuePress",
+        "runtimeExecutable": "npm",
+        "runtimeArgs": [
+            "run-script",
+            "debug"
+        ],
+        "port": 9229
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnPaste": false,
+  "editor.formatOnSave": false,
+}

--- a/docs/.vuepress/theme/util/index.js
+++ b/docs/.vuepress/theme/util/index.js
@@ -197,15 +197,21 @@ export function resolveMatchingConfig (regularPath, config) {
       config: config
     }
   }
-  for (const base in config) {
-    if (ensureEndingSlash(regularPath).indexOf(encodeURI(base)) === 0) {
+  const regularPathWithSlash = ensureEndingSlash(regularPath)
+
+  const matchingConfig = Object.entries(config)
+    .filter(([base, _]) => regularPathWithSlash.indexOf(encodeURI(base)) === 0)
+    .sort(([base, _value], [nextBase, _nextValue]) => {
+      return nextBase.length - base.length;
+    })
+    .map(([base, value]) => {
       return {
         base,
-        config: config[base]
+        config: value
       }
-    }
-  }
-  return {}
+    })[0]
+
+  return matchingConfig || {}
 }
 
 function ensureEndingSlash (path) {

--- a/docs/.vuepress/theme/util/index.js
+++ b/docs/.vuepress/theme/util/index.js
@@ -200,16 +200,9 @@ export function resolveMatchingConfig (regularPath, config) {
   const regularPathWithSlash = ensureEndingSlash(regularPath)
 
   const matchingConfig = Object.entries(config)
-    .filter(([base, _]) => regularPathWithSlash.indexOf(encodeURI(base)) === 0)
-    .sort(([base, _value], [nextBase, _nextValue]) => {
-      return nextBase.length - base.length;
-    })
-    .map(([base, value]) => {
-      return {
-        base,
-        config: value
-      }
-    })[0]
+    .map(([base, config]) => ({ base, config }))
+    .sort(({ base: a }, { base: b }) => b.length - a.length)
+    .find(({ base }) => regularPathWithSlash.includes(base));
 
   return matchingConfig || {}
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "watchpack": "1.6.1"
   },
   "scripts": {
+    "debug": "vuepress dev docs --debug",
     "predocs:build": "node ./import/import-client-docs.js",
     "docs:dev": "vuepress dev docs --no-cache",
     "docs:build": "vuepress build docs",


### PR DESCRIPTION
The sidebar for HTTP API docs was not matched properly. The current code was naively trying to match for the first available matching. For the case where HTTP docs are inside database docs:
- `v5/docs/`
- `v5/docs/http-api/`
It was using the first match. Fixed sidebar pattern matching by taking the longest available matching.

Added also VSCode config for debugging VuePress