### PR TITLE
Add compatibility mode to v5 client docs

### DIFF
--- a/docs/clients/dotnet/5.0/connecting/compatibility-mode.md
+++ b/docs/clients/dotnet/5.0/connecting/compatibility-mode.md
@@ -1,0 +1,64 @@
+# Compatibility Mode
+
+Compatibility Mode was added in v5.0.10 of the client to set certain configuration options depending on the Event Store version the client is connecting to.
+
+At the moment, the v5 client supports two modes:
+
+- "20" to allow connection to Event Store servers v20.6 and above, including v21.2 and above.
+- "auto" to allow discovering whether the Event Store server is a v5 or v20 server.
+
+## Auto-Compatibility Mode
+
+Auto-Compatibility mode was added to make the upgrade from an insecure v5 cluster to a secure v20+ cluster easier by allowing the client to connect to either server configuration without needing to change the client's connection settings.
+
+It does this by sending both an insecure and a secure gossip request when first discovering the server. Whichever of these requests succeeds sets whether the gossip is to be done over HTTP or HTTPS. Once the cluster is discovered, the client will check the gossip to determine whether the TCP connection should be secure or insecure, and connect accordingly.
+
+This means that you no longer need to specify `GossipOverTls` or `UseSslConnection` in the connection settings or connection string.
+
+::: note
+Since auto-compatibility mode will send two requests at discovery and expect one to fail, you will see a gossip failure in the log when the client starts. This is expected to only happen on the first request.
+:::
+
+### Usage
+
+Auto-Compatibility Mode is supported when connecting with Gossip Seeds or Cluster DNS Discovery.  
+You can enable auto-compatibility mode with `CompatibilityMode=auto` in the connection string, or with `.SetCompatibilityMode("auto")` in the connection settings.
+
+You can connect to a cluster running insecure v5, insecure v20+, or secure v20+ with the following configurations:
+
+### Connection String:
+
+```csharp
+var clusterDnsConnectionString = $"ConnectTo=discover://{dns_address}:2113;TargetHost={dns_address};CompatibilityMode=auto;ValidateServer=true;"
+```
+
+```csharp
+var gossipSeedConnectionSTring = $"GossipSeeds={node1}:2113,{node2}:2113,{node3}:2113;CompatibilityMode=auto;ValidateServer=true;"
+```
+
+::: warning
+Auto-compatibility mode does not enable Server Certificate Validation by default. As such, we recommend that you enable this explicitly in your connection string.
+:::
+
+### Connection Settings:
+
+:::: code-group
+::: code Using Cluster DNS Discovery
+<<< @/docs/clients/dotnet/5.0/sample-code/DotNetClient/CompatibilityMode.cs#AutoCompatibilityWithClusterDns
+:::
+::: code Using Gossip Seeds
+<<< @/docs/clients/dotnet/5.0/sample-code/DotNetClient/CompatibilityMode.cs#AutoCompatibilityWithGossipSeeds
+:::
+::::
+
+## v20 Compatibility Mode
+
+The v20 Compatibility Mode allows the v5 client to connect to a cluster running in ES Cloud.
+
+You can set this with `CompatibilityMode=20` in the connection string, or with `.SetCompatibilityMode("20")` in the connection settings.
+
+For example:
+
+```csharp
+var connectionString = $"ConnectTo=discover://{CloudClusterId}.mesdb.eventstore.cloud:2113?UseSslConnection=true;ValidateServer=true;CompatibilityMode=20;"
+```

--- a/docs/clients/dotnet/5.0/connecting/options.md
+++ b/docs/clients/dotnet/5.0/connecting/options.md
@@ -72,7 +72,7 @@ By default information about connection, disconnection and errors are logged, ho
 
 ### User credentials
 
-EventStoreDB supports [Access Control Lists](../../../../server/5.0.9/server/security/acl.md) that restrict permissions for a stream based on users and groups. `EventStoreConnection` allows you to supply credentials for each operation, however it is often more convenient to set default credentials for all operations on the connection.
+EventStoreDB supports [Access Control Lists](/server/generated/v5/docs/security/acl.md) that restrict permissions for a stream based on users and groups. `EventStoreConnection` allows you to supply credentials for each operation, however it is often more convenient to set default credentials for all operations on the connection.
 
 | Builder Method | Description |
 |:---------------|:------------|
@@ -89,7 +89,7 @@ settingsBuilder.SetDefaultUserCredentials(credentials);
 
 The .NET API and EventStoreDB can communicate either over SSL or an unencrypted channel (by default).
 
-To configure the client-side of the SSL connection, use the builder method below. For more information on setting up the server end of the EventStoreDB for SSL, see [SSL Setup](../../../../server/5.0.9/server/security/security.md).
+To configure the client-side of the SSL connection, use the builder method below. For more information on setting up the server end of the EventStoreDB for SSL, see [SSL Setup](/server/generated/v5/docs/security/README.md).
 
 ```csharp
 UseSslConnection(string targetHost, bool validateServer)

--- a/docs/clients/dotnet/5.0/sample-code/DocsExample.csproj
+++ b/docs/clients/dotnet/5.0/sample-code/DocsExample.csproj
@@ -6,7 +6,7 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EventStore.Client" Version="5.0.9" />
+    <PackageReference Include="EventStore.Client" Version="5.0.11" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/docs/clients/dotnet/5.0/sample-code/DotNetClient/CompatibilityMode.cs
+++ b/docs/clients/dotnet/5.0/sample-code/DotNetClient/CompatibilityMode.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.ClientAPI;
+using System.Net;
+
+namespace DocsExample.DotNetClient
+{
+    public class CompatibilityMode
+    {
+        public static async Task AutoCompatibilityWithClusterDns()
+        {
+            var dnsAddress = "my-address";
+            #region AutoCompatibilityWithClusterDns
+            var connectionSettings = ConnectionSettings.Create()
+                .SetCompatibilityMode("auto");
+            var clusterSettings = ClusterSettings.Create()
+                .DiscoverClusterViaDns()
+                .SetClusterDns(dnsAddress)
+                .SetClusterGossipPort(2113);
+
+            var conn = EventStoreConnection.Create(connectionSettings, clusterSettings);
+            await conn.ConnectAsync();
+            #endregion AutoCompatibilityWithClusterDns
+        }
+
+        public static async Task AutoCompatibilityWithGossipSeeds()
+        {
+            var node1 = IPAddress.Loopback;
+            var node2 = IPAddress.Loopback;
+            var node3 = IPAddress.Loopback;
+
+            #region AutoCompatibilityWithGossipSeeds
+            var connectionSettings = ConnectionSettings.Create()
+                .SetGossipSeedEndPoints(
+                    new IPEndPoint(node1, 2113),
+                    new IPEndPoint(node2, 2113),
+                    new IPEndPoint(node3, 2113))
+                .SetCompatibilityMode("auto");
+
+            var conn = EventStoreConnection.Create(connectionSettings);
+            await conn.ConnectAsync();
+            #endregion AutoCompatibilityWithGossipSeeds
+        }
+    }
+}

--- a/docs/clients/dotnet/5.0/sidebar.js
+++ b/docs/clients/dotnet/5.0/sidebar.js
@@ -14,6 +14,7 @@ module.exports = [
             "connecting/",
             "connecting/options.md",
             "connecting/connection-string.md",
+            "connecting/compatibility-mode.md",
         ]
     },
     {

--- a/docs/clients/dotnet/versions.json
+++ b/docs/clients/dotnet/versions.json
@@ -5,7 +5,7 @@
     "basePath": "clients/dotnet",
     "versions": [
       {
-        "version": "5.0.9 (.NET)",
+        "version": "5.0.11 (.NET)",
         "path": "5.0",
         "startPage": "getting-started/"
       }

--- a/docs/server/versions.json
+++ b/docs/server/versions.json
@@ -13,7 +13,7 @@
         "path": "generated/v20.10/docs"
       },
       {
-        "version": "5.0.9",
+        "version": "5.0.10",
         "path": "generated/v5/docs"
       }
     ]
@@ -24,7 +24,7 @@
     "basePath": "server",
     "versions": [
       {
-        "version": "5.0.9",
+        "version": "5.0.10",
         "path": "generated/v5/docs/http-api"
       }
     ]


### PR DESCRIPTION
Also bump the version of the TCP client in the docs examples to v5.0.11