### PR TITLE
follow RFC3986 for keepalive connection string encoding

### DIFF
--- a/docs/.vuepress/modules/common/keepAlive.js
+++ b/docs/.vuepress/modules/common/keepAlive.js
@@ -1,7 +1,7 @@
 import {validateKeepAlive} from "../../lib/validate";
 
 function formatKeepAlive(name, value) {
-    return value !== undefined ? `$${name}=${value};` : "";
+    return value !== undefined ? `&${name}=${value}` : "";
 }
 
 function getKeepAliveValueHelp(isEnabled, name, value) {


### PR DESCRIPTION
:wave: hello!

I was messing around with the gRPC client connection string generator and its keepalive settings (btw thanks y'all for making the connection string generator, it's lovely :slightly_smiling_face:)

I noticed that with these settings:


| option | value |
|--------|-------|
| fetch configuration | specify manually |
| connect to | single node |
| protocol security | secure |
| keepalive | disabled |
| node address | localhost |
| port | 2113 |

I get a connection string of 

```
esdb://localhost:2113?tls=true&keepAliveInterval=-1&keepAliveTimeout=-1
```

but if I enable the keepalive options

| option | value |
|--------|-------|
| fetch configuration | specify manually |
| connect to | single node |
| protocol security | secure |
| keepalive | enabled |
| keepalive interval | 30000 |
| keepalive timeout | 20000 |
| node address | localhost |
| port | 2113 |

I get this connection string:

```
esdb://localhost:2113?tls=true$keepAliveTimeout=20000;$keepAliveInterval=30000;
```

If I'm not mistaken, the `?key1=value1$key2=value2;` syntax for the query params is from RFC2396 ([link to section on query component](https://tools.ietf.org/html/rfc2396#section-3.4)) which has been obsoleted and superceded by RFC3986 ([link to section on queries](https://tools.ietf.org/html/rfc3986#section-3.4)), changing the syntax to `?key1=value1&key2=value2`.

This PR changes from that `$key=value;` syntax from `&key=value` for the keepalive settings. Looking around at the nodejs official client, I see this parser code for reading connection strings ([permalink](https://github.com/EventStore/EventStore-Client-NodeJS/blob/10651063280adb99c2a3e1a4768d25dbd5cce34c/src/Client/parseConnectionString.ts#L185-L190)). My JavaScript chops are pretty rusty but I think it's only written to interperet the `&key=value` syntax. I haven't checked out the rest of the official clients yet but I think generally more recent versions of URI parsers (those built-in to language standard libraries or external libraries) default to only accepting RFC3986.

edit: Looks like the `&key=value` syntax is also used exclusively by the C# client ([permalink](https://github.com/EventStore/EventStore-Client-Dotnet/blob/a853663cb06fcc70db12f0da20956f4afa63f3c7/src/EventStore.Client/EventStoreClientSettings.ConnectionString.cs#L263-L276)), the rust client ([permalink](https://github.com/EventStore/EventStoreDB-Client-Rust/blob/a849511091fbf86419b4a389576014332203571e/src/grpc.rs#L391-L392)), the java client ([permalink](https://github.com/EventStore/EventStoreDB-Client-Java/blob/6cfd2414091add0cc5caa03ae060f110023cafb6/db-client-java/src/main/java/com/eventstore/dbclient/EventStoreDBConnectionString.java#L167-L168)) and the go client ([permalink](https://github.com/EventStore/EventStore-Client-Go/blob/700926402daf00de9453c67269c9cd318d5849fc/client/configuration.go#L20-L22))