### PR TITLE
Ensure text remains visible during webfont load

### DIFF
--- a/docs/.vuepress/theme/styles/palette.styl
+++ b/docs/.vuepress/theme/styles/palette.styl
@@ -9,31 +9,35 @@ $contentWidth = 500px
   font-family: "museosans";
   src: url("/fonts/MuseoSans_700-webfont.woff") format('woff');
   font-weight: 700;
+  font-display: swap;
 }
 
 @font-face {
   font-family: "museosans";
   src: url("/fonts/MuseoSans_500-webfont.woff") format('woff');
   font-weight: 500;
+  font-display: swap;
 }
 
 @font-face {
   font-family: "museosans";
   src: url("/fonts/MuseoSans_300-webfont.woff") format('woff');
   font-weight: 300;
+  font-display: swap;
 }
 
 @font-face {
   font-family: "museosans";
   src: url("/fonts/MuseoSans_100-webfont.woff") format('woff');
   font-weight: 100;
+  font-display: swap;
 }
 
 img
   text-align center
 
 body
-  font-family: museosans
+  font-family: museosans,Arial,sans-serif
   font-weight: 500
   color: #757575
 


### PR DESCRIPTION
Adds `font-display: swap` to font-face declarations and fallback fonts to body text. This allows browsers to show the fallback font whilst webfonts load to reduce flash of invisible text.