### PR TITLE
21.6 Release docs updates

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -36,13 +36,7 @@ export default ({Vue, options, router, siteData}) => {
     Object.assign(options, {
         store: new Vuex.Store(store)
     });
-    router.addRoutes([
-        {
-            path: "/latest.html",
-            redirect: "/server/v21.2/docs/introduction/"
-            //`/${siteData.themeConfig.versions.latest}/introduction/`
-        }
-    ]);
+    router.addRoutes([]);
 
     gtm.addGtm(router, Vue, siteData.themeConfig.gtm);
 

--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -1,5 +1,5 @@
 # Redirects from what the browser requests to what we serve
-/latest.html                       /server/v21.2/docs/introduction/ 301!
+/latest.html                       /server/v21.6/docs/introduction/ 301!
 /server/generated/21.2/docs/*      /server/v21.2/docs/:splat        301!
 /server/v20/server/*               /server/v20.10/docs/:splat       301!
 /server/v5/server/*                /server/v5/docs/:splat           301!

--- a/docs/clients/dotnet/20.10/connecting/compatibility-mode.md
+++ b/docs/clients/dotnet/20.10/connecting/compatibility-mode.md
@@ -3,7 +3,7 @@
 Compatibility Mode was added in v5.0.10 and v21.2.0 of the client to set certain configuration options depending on the Event Store version the client is connecting to. It allows discovering whether the Event Store server is a v5 or v20 server.
 
 ::: warning
-Changes were not backported to the v20.10 TCP Client version. To use `Compatibility Mode` you have to upgrade to v21.2.0. It's fully compatible with v20.10.0. Check the details in the [TCP Compatibility Mode client v21.2 docs](/clients/dotnet/21.2/connecting/compatibility-mode.md).
+Changes were not backported to the v20.10 TCP Client version. To use `Compatibility Mode` you have to upgrade to at least v21.2.0. It's fully compatible with v20.10.0. Check the details in the [TCP Compatibility Mode client v21.2 docs](/clients/dotnet/21.2/connecting/compatibility-mode.md).
 :::
 ## Auto-Compatibility Mode
 
@@ -14,5 +14,5 @@ It does this by sending both an insecure and a secure gossip request when first 
 This means that you no longer need to specify `GossipOverTls` or `UseSslConnection` in the connection settings or connection string.
 
 ::: warning
-Changes were not backported to the v20.10 TCP Client version. To use `Auto-Compatibility Mode` you have to upgrade to v21.2.0. It's fully compatible with v20.10.0. Check the details in the [Auto-Compatibility Mode client v21.2 docs](/clients/dotnet/21.2/connecting/compatibility-mode.md#auto-compatibility-mode).
+Changes were not backported to the v20.10 TCP Client version. To use `Auto-Compatibility Mode` you have to upgrade to at least v21.2.0. It's fully compatible with v20.10.0. Check the details in the [Auto-Compatibility Mode client v21.2 docs](/clients/dotnet/21.2/connecting/compatibility-mode.md#auto-compatibility-mode).
 :::

--- a/docs/server/versions.json
+++ b/docs/server/versions.json
@@ -5,6 +5,10 @@
     "basePath": "server",
     "versions": [
       {
+        "version": "21.6",
+        "path": "generated/v21.6/docs"
+      },
+      {
         "version": "21.2",
         "path": "generated/v21.2/docs"
       },

--- a/import/repos.json
+++ b/import/repos.json
@@ -9,6 +9,10 @@
     "repo": "https://github.com/EventStore/EventStore.git",
     "branches": [
       {
+        "version": "v21.6",
+        "name": "release/oss-v21.6"
+      },
+      {
         "version": "v21.2",
         "name": "release/oss-v21.2"
       },


### PR DESCRIPTION
1. Added 21.6 database docs version.
2. Updated wording in TCP auto-compatibility mode docs and docker-compose to the latest release version.

TODO:
- [x] Make sure that https://github.com/EventStore/EventStore/pull/2989/files is merged
- [x] Make sure that https://github.com/EventStore/EventStore/pull/2987 is merged and propagated to the `release/oss-v20.10`, `release/oss-v21.2`, `master` branches.

Taken out of this PR (as clients are not yet released):
- Add the .NET TCP Client release once it's done. Based on the @hayley-jean, it's unclear yet when and what will be released.
- Update other gRPC clients versions once they're released
- Uncomment Persistent subscription to `$all` gRPC docs