### PR TITLE
Fix 404 internal link redirection

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -1,6 +1,6 @@
 # Redirects from what the browser requests to what we serve
 /latest.html                       /server/v21.6/docs/introduction/ 301!
-/server/generated/21.2/docs/*      /server/v21.2/docs/:splat        301!
+/server/generated/*                /server/:splat                   301!
 /server/v20/server/*               /server/v20.10/docs/:splat       301!
 /server/v5/server/*                /server/v5/docs/:splat           301!
 /server/5.0.8/server/*             /server/v5/docs/:splat           301!


### PR DESCRIPTION
Some time ago, I added the URL rewriter VuePress module:
- https://github.com/EventStore/documentation/blob/master/docs/.vuepress/plugins/remove_generated_from_url.js

It takes the current URL and removes the `generated` part if it exists. However, there are no real redirects, but it's just the VuePress router. 

It only works, for the URL when it's resolved (so it maps the URL to a physical file, that's the same). Links generated by VuePress don't go through this module. So links are still targeting the URL with `/generated/`, but as they don't exist, then we got the 404. The URL was rewritten, but only on the browser URL. That's why refreshing the page helped, as then the page was accessed with the rewrote URL.

Fixed that by adding the server redirection.

Fixes #315.