### PR TITLE
Split production build into separate NPM tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ Documentation is written using [VuePress](https://vuepress.vuejs.org/).
 2. Run `yarn install`
 3. Run `yarn docs:dev`
 
+### Running production build
+
+To run the production build that will import documentation from database and client repositories run:
+
+```bash
+yarn docs:build-prod
+```
+
+To import documentation from external repositories:
+
+```bash
+yarn docs:import
+```
+
+To build documentation without importing documentation:
+
+```bash
+yarn docs:build
+```
+
 ### Algolia Search
 
 Documentation is using Algolia for indexing and searching through the contents.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
     publish = "public/"
-    command = "yarn docs:build"
+    command = "yarn docs:build-prod"

--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
   },
   "scripts": {
     "debug": "vuepress dev docs --debug",
-    "predocs:build": "node ./import/import-client-docs.js",
     "docs:dev": "vuepress dev docs --no-cache",
     "docs:build": "vuepress build docs",
+    "docs:build-prod": "yarn docs:import && yarn docs:build",
+    "docs:import": "node ./import/import-client-docs.js",
     "swagger": "swagger-markdown -i docs/server/5.0/http-api/swagger.yaml"
   }
 }


### PR DESCRIPTION
Split production build into separate NPM tasks. That enables importing docs and building docs separately while working locally