### PR TITLE
Added nightly schedules for the Deployment to Netlify and Scraping to Algolia

### DIFF
--- a/.github/workflows/algolia-scraper.yml
+++ b/.github/workflows/algolia-scraper.yml
@@ -3,7 +3,9 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch:
+  workflow_dispatch:  
+  schedule:
+    - cron: "0 1 * * *" #runs at 01:00 UTC everyday
 jobs:
   scrape:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,14 @@
+name: nightly-build
+on:
+  workflow_dispatch: 
+  schedule:
+    - cron: "0 0 * * *" #runs at 00:00 UTC everyday
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Netlify Build
+        env:
+          NETLIFY_HOOK_ID: ${{ secrets.NETLIFY_HOOK_ID }}
+        run: |
+          curl -X POST -d {} "https://api.netlify.com/build_hooks/$NETLIFY_HOOK_ID"


### PR DESCRIPTION

Currently, documentation builds are not triggered if something changed in the specific repos (e.g. database, client). That requires to remember to call them manually.
Also, scraping is called on merge (because of the Netlify integration limitation), so there might be a race condition if scraping started before deployment finishes.

Scheduling builds:
- Deployment at 00:00,
- Scraping at 01:00
will make sure that documentation and search will be stale for at most 1 day.