### PR TITLE
Remove mention of autoAck

### DIFF
--- a/docs/clients/grpc/persistent-subscriptions.md
+++ b/docs/clients/grpc/persistent-subscriptions.md
@@ -6,12 +6,12 @@ The first step of dealing with a subscription group is to create one. You will r
 
 @[code{create-persistent-subscription-to-stream}](@grpc:persistent-subscriptions/Program.cs;persistentSubscriptions.go;persistent_subscriptions/PersistentSubscriptions.java;persistent-subscriptions.js;persistent_subscriptions.rs;persistent-subscriptions.ts)
 
-| Parameter     | Description                                         |
+| Parameter | Description |
 |:--------------|:----------------------------------------------------|
-| `stream`      | The stream the persistent subscription is on.       |
-| `groupName`   | The name of the subscription group to create.       |
-| `settings`    | The settings to use when creating the subscription. |
-| `credentials` | The user credentials to use for this operation.     |
+| `stream` | The stream the persistent subscription is on. |
+| `groupName` | The name of the subscription group to create. |
+| `settings` | The settings to use when creating the subscription. |
+| `credentials` | The user credentials to use for this operation. |
 
 ## Connecting to a subscription group
 
@@ -21,15 +21,15 @@ The most important parameter to pass when connecting is the buffer size. This re
 
 @[code{subscribe-to-persistent-subscription-to-stream}](@grpc:persistent-subscriptions/Program.cs;persistentSubscriptions.go;persistent_subscriptions/PersistentSubscriptions.java;persistent-subscriptions.js;persistent_subscriptions.rs;persistent-subscriptions.ts)
 
-| Parameter             | Description                                                                                  |
+| Parameter | Description |
 |:----------------------|:---------------------------------------------------------------------------------------------|
-| `stream`              | The stream the persistent subscription is on.                                                |
-| `groupName`           | The name of the subscription group to subscribe to.                                          |
-| `eventAppeared`       | The action to call when an event arrives over the subscription.                              |
-| `subscriptionDropped` | The action to call if the subscription is dropped.                                           |
-| `credentials`         | The user credentials to use for this operation.                                              |
+| `stream` | The stream the persistent subscription is on. |
+| `groupName` | The name of the subscription group to subscribe to. |
+| `eventAppeared` | The action to call when an event arrives over the subscription. |
+| `subscriptionDropped` | The action to call if the subscription is dropped. |
+| `credentials` | The user credentials to use for this operation. |
 | `bufferSize`          | The number of in-flight messages this client is allowed. **Default: 10**                     |
-| `autoAck`             | Whether to automatically acknowledge messages after eventAppeared returns. **Default: true** |
+| `autoAck` | Whether to automatically acknowledge messages after eventAppeared returns. **Default: true** |
 
 ## Subscribing to $all
 
@@ -89,20 +89,20 @@ And then subscribing to it is done in much the same way:
 
 ## Acknowledgements
 
-Clients must acknowledge (or not acknowledge) messages in the competing consumer model. If you enable auto-ack the subscription will automatically acknowledge messages once your handler completes them. If an error occurs, it will shut down your subscription with a message and the error.
+Clients must acknowledge (or not acknowledge) messages in the competing consumer model.
 
-You can choose to not auto-ack messages. This can be useful when you have multi-threaded processing of messages in your subscriber and need to pass control to something else. If you want to manually acknowledge events, you need to set this option when subscribing and then acknowledge or not acknowledge messages as you handle them.
+If processing is successful, you must send an Ack (Acknowledge) to the server to let it know that the message has been handled. If processing fails for some reason, then you can Nack (Not Acknowledge) the message and tell the server how to handle the failure.
 
 @[code{subscribe-to-persistent-subscription-with-manual-acks}](@grpc:persistent-subscriptions/Program.cs;persistentSubscriptions.go;persistent_subscriptions/PersistentSubscriptions.java;persistent-subscriptions.js;persistent_subscriptions.rs;persistent-subscriptions.ts)
 
 The Nak Actions describe what the server should do with the message:
 
-| Action    | Description                                                          |
+| Action | Description |
 |:----------|:---------------------------------------------------------------------|
 | `Unknown` | The client does not know what action to take. Let the server decide. |
-| `Park`    | Park the message and do not resend. Put it on poison queue.          |
-| `Retry`   | Explicitly retry the message.                                        |
-| `Skip`    | Skip this message do not resend and do not put in poison queue.      |
+| `Park` | Park the message and do not resend. Put it on poison queue. |
+| `Retry` | Explicitly retry the message. |
+| `Skip` | Skip this message do not resend and do not put in poison queue. |
 
 ## Consumer strategies
 
@@ -134,12 +134,12 @@ You can edit the settings of an existing subscription group while it is running,
 
 @[code{update-persistent-subscription}](@grpc:persistent-subscriptions/Program.cs;persistentSubscriptions.go;persistent_subscriptions/PersistentSubscriptions.java;persistent-subscriptions.js;persistent_subscriptions.rs;persistent-subscriptions.ts)
 
-| Parameter     | Description                                         |
+| Parameter | Description |
 |:--------------|:----------------------------------------------------|
-| `stream`      | The stream the persistent subscription is on.       |
-| `groupName`   | The name of the subscription group to update.       |
-| `settings`    | The settings to use when creating the subscription. |
-| `credentials` | The user credentials to use for this operation.     |
+| `stream` | The stream the persistent subscription is on. |
+| `groupName` | The name of the subscription group to update. |
+| `settings` | The settings to use when creating the subscription. |
+| `credentials` | The user credentials to use for this operation. |
 
 ## Persistent subscription settings
 
@@ -147,21 +147,21 @@ Both the `Create` and `Update` methods take some settings for configuring the pe
 
 The following table shows the configuration options you can set on a persistent subscription.
 
-| Option                  | Description                                                                                                                       | Default                                   |
+| Option | Description | Default |
 |:------------------------|:----------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------|
-| `ResolveLinkTos`        | Whether the subscription should resolve link events to their linked events.                                                       | `false`                                   |
-| `StartFrom`             | The exclusive position in the stream or transaction file the subscription should start from.                                      | `null` (start from the end of the stream) |
-| `ExtraStatistics`       | Whether to track latency statistics on this subscription.                                                                         | `false`                                   |
-| `MessageTimeout`        | The amount of time after which to consider a message as timed out and retried.                                                    | `30` (seconds)                            |
-| `MaxRetryCount`         | The maximum number of retries (due to timeout) before a message is considered to be parked.                                       | `10`                                      |
-| `LiveBufferSize`        | The size of the buffer (in-memory) listening to live messages as they happen before paging occurs.                                | `500`                                     |
-| `ReadBatchSize`         | The number of events read at a time when paging through history.                                                                  | `20`                                      |
-| `HistoryBufferSize`     | The number of events to cache when paging through history.                                                                        | `500`                                     |
-| `CheckPointAfter`       | The amount of time to try to checkpoint after.                                                                                    | `2` seconds                               |
-| `MinCheckPointCount`    | The minimum number of messages to process before a checkpoint may be written.                                                     | `10`                                      |
-| `MaxCheckPointCount`    | The maximum number of messages not checkpointed before forcing a checkpoint.                                                      | `1000`                                    |
-| `MaxSubscriberCount`    | The maximum number of subscribers allowed.                                                                                        | `0` (unbounded)                           |
-| `NamedConsumerStrategy` | The strategy to use for distributing events to client consumers. See the [consumer strategies](#consumer-strategies) in this doc. | `RoundRobin`                              |
+| `ResolveLinkTos` | Whether the subscription should resolve link events to their linked events. | `false` |
+| `StartFrom` | The exclusive position in the stream or transaction file the subscription should start from. | `null` (start from the end of the stream) |
+| `ExtraStatistics` | Whether to track latency statistics on this subscription. | `false` |
+| `MessageTimeout` | The amount of time after which to consider a message as timed out and retried. | `30` (seconds) |
+| `MaxRetryCount` | The maximum number of retries (due to timeout) before a message is considered to be parked. | `10` |
+| `LiveBufferSize` | The size of the buffer (in-memory) listening to live messages as they happen before paging occurs. | `500` |
+| `ReadBatchSize` | The number of events read at a time when paging through history. | `20` |
+| `HistoryBufferSize` | The number of events to cache when paging through history. | `500` |
+| `CheckPointAfter` | The amount of time to try to checkpoint after. | `2` seconds |
+| `MinCheckPointCount` | The minimum number of messages to process before a checkpoint may be written. | `10` |
+| `MaxCheckPointCount` | The maximum number of messages not checkpointed before forcing a checkpoint. | `1000` |
+| `MaxSubscriberCount` | The maximum number of subscribers allowed. | `0` (unbounded) |
+| `NamedConsumerStrategy` | The strategy to use for distributing events to client consumers. See the [consumer strategies](#consumer-strategies) in this doc. | `RoundRobin` |
 
 ## Deleting a subscription group
 
@@ -169,8 +169,8 @@ Remove a subscription group with the delete operation. Like the creation of grou
 
 @[code{delete-persistent-subscription}](@grpc:persistent-subscriptions/Program.cs;persistentSubscriptions.go;persistent_subscriptions/PersistentSubscriptions.java;persistent-subscriptions.js;persistent_subscriptions.rs;persistent-subscriptions.ts)
 
-| Parameter     | Description                                    |
+| Parameter | Description |
 |:--------------|:-----------------------------------------------|
-| `stream`      | The stream the persistent subscription is on.  |
-| `groupName`   | The name of the subscription group to delete.  |
+| `stream` | The stream the persistent subscription is on. |
+| `groupName` | The name of the subscription group to delete. |
 | `credentials` | The user credentials to use for this operation |


### PR DESCRIPTION
Removes mention of auto-ack from the documentation following PR https://github.com/EventStore/EventStore-Client-Dotnet/pull/175 and RFC010  about [Acks and Nacks in Persistent Subscriptions](https://github.com/EventStore/architecture-and-planning/blob/main/rfcs/010%20-%20Persistent%20Subscriptions%20Acks%20and%20Nacks.md).