### PR TITLE
Fix `JavaScript` label in installation section

### DIFF
--- a/docs/clients/grpc/README.md
+++ b/docs/clients/grpc/README.md
@@ -51,7 +51,7 @@ implementation 'com.eventstore:db-client-java:0.5'
 libraryDependencies += "com.eventstore" % "db-client-java" % "0.6"
 ```
 :::
-::: code-group-item NodeJS
+::: code-group-item JavaScript
 ```:no-line-numbers
 # Yarn
 $ yarn add @eventstore/db-client
@@ -67,6 +67,8 @@ No additional configuration is needed having Rust installed. Go check https://ru
 :::
 ::: code-group-item TypeScript
 ```:no-line-numbers
+# TypeScript Declarations are included in the package.
+
 # Yarn
 $ yarn add @eventstore/db-client
 

--- a/docs/clients/grpc/projections.md
+++ b/docs/clients/grpc/projections.md
@@ -56,6 +56,8 @@ No additional configuration is needed having Rust installed. Go check https://ru
 :::
 ::: code-group-item TypeScript
 ```
+# TypeScript Declarations are included in the package.
+
 # Yarn
 $ yarn add @eventstore/db-client
 


### PR DESCRIPTION
- Fix `JavaScript` label in installation section
- Add note about declarations in `TypeScript` installation section