### PR TITLE
Unified snippets approach and fixed broken snippets links

### DIFF
--- a/docs/clients/grpc/README.md
+++ b/docs/clients/grpc/README.md
@@ -102,26 +102,7 @@ We use JSON for serialization in the documentation examples.
 
 The code snippet below creates an event object instance, serializes it and puts it as payload to the `EventData` structure, which the client is able to write to the database.
 
-:::: code-group
-::: code-group-item C#
-@[code{createEvent}](../dotnet/21.2/samples/quick-start/Program.cs)
-:::
-::: code-group-item Go
-@[code{createEvent}](../go/1.0.0/samples/quickstart.go)
-:::
-::: code-group-item Java
-@[code{createEvent}](../java/1.0.0/samples/quick_start/QuickStart.java)
-:::
-::: code-group-item JavaScript
-@[code{createEvent}](../node/2.0.0/samples/get-started.js)
-:::
-::: code-group-item Rust
-@[code{createEvent}](../rust/1.0.0/samples/quickstart.rs)
-:::
-::: code-group-item TypeScript
-@[code{createEvent}](../node/2.0.0/samples/get-started.ts)
-:::
-::::
+@[code{createEvent}](@grpc:quick-start/Program.cs;quickstart.go;quick_start/QuickStart.java;get-started.js;quickstart.rs;get-started.ts)
 
 ### Appending events
 
@@ -129,26 +110,7 @@ Each event in the database has its own unique identifier (UUID). The database us
 
 In the snippet below, we append the event to the stream `some-stream`.
 
-:::: code-group
-::: code-group-item C#
-@[code{appendEvents}](../dotnet/21.2/samples/quick-start/Program.cs)
-:::
-::: code-group-item Go
-@[code{appendEvents}](../go/1.0.0/samples/quickstart.go)
-:::
-::: code-group-item Java
-@[code{appendEvents}](../java/1.0.0/samples/quick_start/QuickStart.java)
-:::
-::: code-group-item JavaScript
-@[code{appendEvents}](../node/2.0.0/samples/get-started.js)
-:::
-::: code-group-item Rust
-@[code{appendEvents}](../rust/1.0.0/samples/quickstart.rs)
-:::
-::: code-group-item TypeScript
-@[code{appendEvents}](../node/2.0.0/samples/get-started.ts)
-:::
-::::
+@[code{appendEvents}](@grpc:quick-start/Program.cs;quickstart.go;quick_start/QuickStart.java;get-started.js;quickstart.rs;get-started.ts)
 
 Here we are appending events without checking if the stream exists or if the stream version matches the expected event version. See more advanced scenarios in [appending events documentation](./appending-events.md).
 
@@ -156,26 +118,7 @@ Here we are appending events without checking if the stream exists or if the str
 
 Finally, we can read events back from the `some-stream` stream.
 
-:::: code-group
-::: code-group-item C#
-@[code{readStream}](@grpc/quick-start/Program.cs)
-:::
-::: code-group-item Go
-@[code{readStream}](../go/1.0.0/samples/quickstart.go)
-:::
-::: code-group-item Java
-@[code{readStream}](@grpc/quick_start/QuickStart.java)
-:::
-::: code-group-item JavaScript
-@[code{readStream}](@grpc/get-started.js)
-:::
-::: code-group-item Rust
-@[code{readStream}](@grpc/quickstart.rs)
-:::
-::: code-group-item TypeScript
-@[code{readStream}](@grpc/get-started.ts)
-:::
-::::
+@[code{readStream}](@grpc:quick-start/Program.cs;quickstart.go;quick_start/QuickStart.java;get-started.js;quickstart.rs;get-started.ts)
 
 When you read events from the stream, you get a collection of `ResolvedEvent` structures. The event payload is returned as a byte array and needs to be deserialized. See more advanced scenarios in [reading events documentation](./reading-events.md).
 

--- a/docs/clients/grpc/appending-events.md
+++ b/docs/clients/grpc/appending-events.md
@@ -10,26 +10,7 @@ Check [connecting to EventStoreDB instructions](./README.md#required-packages) t
 
 The simplest way to append an event to EventStoreDB is to create an `EventData` object and call `AppendToStream` method.
 
-:::: code-group
-::: code-group-item C#
-@[code{append-to-stream}](../dotnet/21.2/samples/appending-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{append-to-stream}](../go/1.0.0/samples/appendingEvents.go)
-:::
-::: code-group-item Java
-@[code{append-to-stream}](../java/1.0.0/samples/appending_events/AppendingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{append-to-stream}](../node/2.0.0/samples/appending-events.js)
-:::
-::: code-group-item Rust
-@[code{append-to-stream}](../rust/1.0.0/samples/appending_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{append-to-stream}](../node/2.0.0/samples/appending-events.ts)
-:::
-::::
+@[code{append-to-stream}](@grpc:appending-events/Program.cs;appendingEvents.go;appending_events/AppendingEvents.java;appending-events.js;appending_events.rs;appending-events.ts)
 
 As you can see, `AppendToStream` takes a collection of `EventData`, which makes possible saving more than one event in a single batch.
  
@@ -49,26 +30,7 @@ This takes the format of a `Uuid` and is used to uniquely identify the event you
 
 For example, the following code will only append a single event:
 
-:::: code-group
-::: code-group-item C#
-@[code{append-duplicate-event}](../dotnet/21.2/samples/appending-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{append-duplicate-event}](../go/1.0.0/samples/appendingEvents.go)
-:::
-::: code-group-item Java
-@[code{append-duplicate-event}](../java/1.0.0/samples/appending_events/AppendingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{append-duplicate-event}](../node/2.0.0/samples/appending-events.js)
-:::
-::: code-group-item Rust
-@[code{append-duplicate-event}](../rust/1.0.0/samples/appending_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{append-duplicate-event}](../node/2.0.0/samples/appending-events.ts)
-:::
-::::
+@[code{append-duplicate-event}](@grpc:appending-events/Program.cs;appendingEvents.go;appending_events/AppendingEvents.java;appending-events.js;appending_events.rs;appending-events.ts)
 
 ::: card
 ![Duplicate Event](./images/dupicate-event.png)
@@ -98,26 +60,7 @@ When appending events to a stream you can supply a *stream state* or *stream rev
 
 For example if we try and append the same record twice expecting both times that the stream doesn't exist we will get an exception on the second:
 
-:::: code-group
-::: code-group-item C#
-@[code{append-with-no-stream}](../dotnet/21.2/samples/appending-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{append-with-no-stream}](../go/1.0.0/samples/appendingEvents.go)
-:::
-::: code-group-item Java
-@[code{append-with-no-stream}](../java/1.0.0/samples/appending_events/AppendingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{append-with-no-stream}](../node/2.0.0/samples/appending-events.js)
-:::
-::: code-group-item Rust
-@[code{append-with-no-stream}](../rust/1.0.0/samples/appending_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{append-with-no-stream}](../node/2.0.0/samples/appending-events.ts)
-:::
-::::
+@[code{append-with-no-stream}](@grpc:appending-events/Program.cs;appendingEvents.go;appending_events/AppendingEvents.java;appending-events.js;appending_events.rs;appending-events.ts)
 
 There are three available stream states: 
 - `Any`
@@ -126,26 +69,7 @@ There are three available stream states:
 
 This check can be used to implement optimistic concurrency. When you retrieve a stream from EventStoreDB, you take note of the current version number, then when you save it back you can determine if somebody else has modified the record in the meantime.
 
-:::: code-group
-::: code-group-item C#
-@[code{append-with-concurrency-check}](../dotnet/21.2/samples/appending-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{append-with-concurrency-check}](../go/1.0.0/samples/appendingEvents.go)
-:::
-::: code-group-item Java
-@[code{append-with-concurrency-check}](../java/1.0.0/samples/appending_events/AppendingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{append-with-concurrency-check}](../node/2.0.0/samples/appending-events.js)
-:::
-::: code-group-item Rust
-@[code{append-with-concurrency-check}](../rust/1.0.0/samples/appending_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{append-with-concurrency-check}](../node/2.0.0/samples/appending-events.ts)
-:::
-::::
+@[code{append-with-concurrency-check}](@grpc:appending-events/Program.cs;appendingEvents.go;appending_events/AppendingEvents.java;appending-events.js;appending_events.rs;appending-events.ts)
 
 <!-- ## Options TODO -->
 
@@ -153,23 +77,5 @@ This check can be used to implement optimistic concurrency. When you retrieve a 
 
 You can provide user credentials to be used to append the data as follows. This will override the default credentials set on the connection.
 
-:::: code-group
-::: code-group-item C#
-@[code{overriding-user-credentials}](../dotnet/21.2/samples/appending-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{overriding-user-credentials}](../go/1.0.0/samples/appendingEvents.go)
-:::
-::: code-group-item Java
-@[code{overriding-user-credentials}](../java/1.0.0/samples/appending_events/AppendingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{overriding-user-credentials}](../node/2.0.0/samples/appending-events.js)
-:::
-::: code-group-item Rust
-@[code{overriding-user-credentials}](../rust/1.0.0/samples/appending_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{overriding-user-credentials}](../node/2.0.0/samples/appending-events.ts)
-:::
-::::
+@[code{overriding-user-credentials}](@grpc:appending-events/Program.cs;appendingEvents.go;appending_events/AppendingEvents.java;appending-events.js;appending_events.rs;appending-events.ts)
+

--- a/docs/clients/grpc/persistent-subscriptions.md
+++ b/docs/clients/grpc/persistent-subscriptions.md
@@ -5,7 +5,7 @@
 The first step of dealing with a subscription group is to create one. You will receive an error if you attempt to create a subscription group multiple times. You must have admin permissions to create a persistent subscription group.
 
 
-@[code{create-persistent-subscription-to-stream}](@grpc/persistent-subscriptions/Program.cs;@grpc/persistentSubscriptions.go;@grpc/persistent_subscriptions/PersistentSubscriptions.java;@grpc/persistent-subscriptions.js;@grpc/persistent_subscriptions.rs;@grpc/persistent-subscriptions.ts)
+@[code{create-persistent-subscription-to-stream}](@grpc:persistent-subscriptions/Program.cs;persistentSubscriptions.go;persistent_subscriptions/PersistentSubscriptions.java;persistent-subscriptions.js;persistent_subscriptions.rs;persistent-subscriptions.ts)
 
 | Parameter | Description |
 |:----------|:------------|
@@ -20,7 +20,7 @@ Once you have created a subscription group, clients can connect to that subscrip
 
 The most important parameter to pass when connecting is the buffer size. This represents how many outstanding messages the server should allow this client. If this number is too small, your subscription will spend much of its time idle as it waits for an acknowledgment to come back from the client. If it's too big, you waste resources and can start causing time out messages depending on the speed of your processing.
 
-@[code{subscribe-to-persistent-subscription-to-stream}](@grpc/persistent-subscriptions/Program.cs;@grpc/persistentSubscriptions.go;@grpc/persistent_subscriptions/PersistentSubscriptions.java;@grpc/persistent-subscriptions.js;@grpc/persistent_subscriptions.rs;@grpc/persistent-subscriptions.ts)
+@[code{subscribe-to-persistent-subscription-to-stream}](@grpc:persistent-subscriptions/Program.cs;persistentSubscriptions.go;persistent_subscriptions/PersistentSubscriptions.java;persistent-subscriptions.js;persistent_subscriptions.rs;persistent-subscriptions.ts)
 
 
 | Parameter | Description |
@@ -46,19 +46,19 @@ You can create a subscription group on $all much the same way you would create a
 ```
 :::
 ::: code-group-item Go
-@[code{create-persistent-subscription-to-all}](@grpc/persistentSubscriptions.go)
+@[code{create-persistent-subscription-to-all}](@grpc:persistentSubscriptions.go)
 :::
 ::: code-group-item Java
-@[code{create-persistent-subscription-to-all}](@grpc/persistent_subscriptions/PersistentSubscriptions.java)
+@[code{create-persistent-subscription-to-all}](@grpc:persistent_subscriptions/PersistentSubscriptions.java)
 :::
 ::: code-group-item JavaScript
-@[code{create-persistent-subscription-to-all}](@grpc/persistent-subscriptions.js)
+@[code{create-persistent-subscription-to-all}](@grpc:persistent-subscriptions.js)
 :::
 ::: code-group-item Rust
-@[code{create-persistent-subscription-to-all}](@grpc/persistent_subscriptions.rs)
+@[code{create-persistent-subscription-to-all}](@grpc:persistent_subscriptions.rs)
 :::
 ::: code-group-item TypeScript
-@[code{create-persistent-subscription-to-all}](@grpc/persistent-subscriptions.ts)
+@[code{create-persistent-subscription-to-all}](@grpc:persistent-subscriptions.ts)
 :::
 ::::
 
@@ -71,21 +71,21 @@ And then subscribing to it is done in much the same way:
 ```
 :::
 ::: code-group-item Go
-@[code{subscribe-to-persistent-subscription-to-all}](@grpc/persistentSubscriptions.go)
+@[code{subscribe-to-persistent-subscription-to-all}](@grpc:persistentSubscriptions.go)
 :::
 ::: code-group-item Java
-@[code{subscribe-to-persistent-subscription-to-all}](@grpc/persistent_subscriptions/PersistentSubscriptions.java)
+@[code{subscribe-to-persistent-subscription-to-all}](@grpc:persistent_subscriptions/PersistentSubscriptions.java)
 :::
 ::: code-group-item JavaScript
-@[code{subscribe-to-persistent-subscription-to-all}](@grpc/persistent-subscriptions.js)
+@[code{subscribe-to-persistent-subscription-to-all}](@grpc:persistent-subscriptions.js)
 :::
 ::: code-group-item Rust
 ```
-Sample available soon
+@[code{subscribe-to-persistent-subscription-to-all}](@grpc:persistent_subscriptions.rs)
 ```
 :::
 ::: code-group-item TypeScript
-@[code{subscribe-to-persistent-subscription-to-all}](@grpc/persistent-subscriptions.ts)
+@[code{subscribe-to-persistent-subscription-to-all}](@grpc:persistent-subscriptions.ts)
 :::
 ::::
 
@@ -95,7 +95,7 @@ Clients must acknowledge (or not acknowledge) messages in the competing consumer
 
 You can choose to not auto-ack messages. This can be useful when you have multi-threaded processing of messages in your subscriber and need to pass control to something else. If you want to manually acknowlegde events, you need to set this option when subscribing and then acknowledge or not acknowledge messages as you handle them.
 
-@[code{subscribe-to-persistent-subscription-with-manual-acks}](@grpc/persistent-subscriptions/Program.cs;@grpc/persistentSubscriptions.go;@grpc/persistent_subscriptions/PersistentSubscriptions.java;@grpc/persistent-subscriptions.js;@grpc/persistent_subscriptions.rs;@grpc/persistent-subscriptions.ts)
+@[code{subscribe-to-persistent-subscription-with-manual-acks}](@grpc:persistent-subscriptions/Program.cs;persistentSubscriptions.go;persistent_subscriptions/PersistentSubscriptions.java;persistent-subscriptions.js;persistent_subscriptions.rs;persistent-subscriptions.ts)
 
 The Nak Actions describe what the server should do with the message:
 
@@ -134,7 +134,7 @@ The main aim of this strategy is to decrease the likelihood of concurrency and o
 
 You can edit the settings of an existing subscription group while it is running, you don't need to delete and recreate it to change settings. When you update the subscription group, it resets itself internally, dropping the connections and having them reconnect. You must have admin permissions to update a persistent subscription group.
 
-@[code{update-persistent-subscription}](@grpc/persistent-subscriptions/Program.cs;@grpc/persistentSubscriptions.go;@grpc/persistent_subscriptions/PersistentSubscriptions.java;@grpc/persistent-subscriptions.js;@grpc/persistent_subscriptions.rs;@grpc/persistent-subscriptions.ts)
+@[code{update-persistent-subscription}](@grpc:persistent-subscriptions/Program.cs;persistentSubscriptions.go;persistent_subscriptions/PersistentSubscriptions.java;persistent-subscriptions.js;persistent_subscriptions.rs;persistent-subscriptions.ts)
 
 | Parameter | Description |
 |:----------|:------------|
@@ -169,7 +169,7 @@ The following table shows the configuration options you can set on a persistent 
 
 Remove a subscription group with the delete operation. Like the creation of groups, you rarely do this in your runtime code and is undertaken by an administrator running a script.
 
-@[code{delete-persistent-subscription}](@grpc/persistent-subscriptions/Program.cs;@grpc/persistentSubscriptions.go;@grpc/persistent_subscriptions/PersistentSubscriptions.java;@grpc/persistent-subscriptions.js;@grpc/persistent_subscriptions.rs;@grpc/persistent-subscriptions.ts)
+@[code{delete-persistent-subscription}](@grpc:persistent-subscriptions/Program.cs;persistentSubscriptions.go;persistent_subscriptions/PersistentSubscriptions.java;persistent-subscriptions.js;persistent_subscriptions.rs;persistent-subscriptions.ts)
 
 | Parameter | Description |
 | :-------- | :---------- |

--- a/docs/clients/grpc/projections.md
+++ b/docs/clients/grpc/projections.md
@@ -6,7 +6,7 @@ The various gRPC client APIs include dedicated clients that allow you to manage 
 Currently not all clients fully expose all operations.
 :::
 
-For a detailed explanation of projections, see the [server documentation](../../server/v21.6/projections/).
+For a detailed explanation of projections, see the [server documentation](../../server/v21.10/projections/).
 
 You can find the full sample code from these documentation on the respective [clients repositories](https://github.com/eventStore/?q=client)
 
@@ -74,7 +74,7 @@ Projection management operations are exposed through a dedicated client.
 <xode-group>
 <xode-block title="C#" code="connectionString">
 
-@[code{createClient}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{createClient}](@grpc:projection-management/Program.cs)
 
 </xode-block>
 <xode-block title="Go" code="connectionString">
@@ -92,7 +92,7 @@ Sample available soon
 </xode-block>
 <xode-block title="JavaScript" code="connectionString">
 
-@[code{createClient}](../node/2.0.0/samples/projection-management.js)
+@[code{createClient}](@grpc:projection-management.js)
 
 </xode-block>
 <xode-block title="Rust" code="connectionString">
@@ -104,7 +104,7 @@ Sample available soon
 </xode-block>
 <xode-block title="TypeScript" code="connectionString">
 
-@[code{createClient}](../node/2.0.0/samples/projection-management.ts)
+@[code{createClient}](@grpc:projection-management.ts)
 
 </xode-block>
 </xode-group>
@@ -116,7 +116,7 @@ Projections have explicit names, and you can enable or disable them via this nam
 
 :::: code-group
 ::: code-group-item C#
-@[code{CreateContinuous}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{CreateContinuous}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -129,7 +129,7 @@ Sample available soon
 ```
 :::
 ::: code-group-item JavaScript
-@[code{CreateContinuous}](../node/2.0.0/samples/projection-management.js)
+@[code{CreateContinuous}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -137,7 +137,7 @@ Sample available soon
 ```
 :::
 ::: code-group-item TypeScript
-@[code{CreateContinuous}](../node/2.0.0/samples/projection-management.ts)
+@[code{CreateContinuous}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -145,7 +145,7 @@ Trying to create projections with the same name will result in an error:
 
 :::: code-group
 ::: code-group-item C#
-@[code{CreateContinuous_Conflict}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{CreateContinuous_Conflict}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -158,7 +158,7 @@ Sample available soon
 ```
 :::
 ::: code-group-item JavaScript
-@[code{CreateContinuous_Conflict}](../node/2.0.0/samples/projection-management.js)
+@[code{CreateContinuous_Conflict}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -166,7 +166,7 @@ Sample available soon
 ```
 :::
 ::: code-group-item TypeScript
-@[code{CreateContinuous_Conflict}](../node/2.0.0/samples/projection-management.ts)
+@[code{CreateContinuous_Conflict}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -175,7 +175,7 @@ Restarts the entire projection subsystem. The user must be in the `$ops` or `$ad
 
 :::: code-group
 ::: code-group-item C#
-@[code{RestartSubSystem}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{RestartSubSystem}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -188,7 +188,7 @@ Restarts the entire projection subsystem. The user must be in the `$ops` or `$ad
 ```
 :::
 ::: code-group-item JavaScript
-@[code{RestartSubSystem}](../node/2.0.0/samples/projection-management.js)
+@[code{RestartSubSystem}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```
@@ -196,7 +196,7 @@ Sample available soon
 ```
 :::
 ::: code-group-item TypeScript
-@[code{RestartSubSystem}](../node/2.0.0/samples/projection-management.ts)
+@[code{RestartSubSystem}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -204,11 +204,11 @@ Sample available soon
 
 Enables an existing projection by name.
 Once enabled, the projection will start to process events even after restarting the server or the projection subsystem.
-You must have access to a projection to enable it, see the [ACL documentation](../../server/v21.6/security/acl.md#stream-acl)
+You must have access to a projection to enable it, see the [ACL documentation](../../server/v21.10/security/acl.md#stream-acl)
 
 :::: code-group
 ::: code-group-item C#
-@[code{Enable}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{Enable}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -221,7 +221,7 @@ You must have access to a projection to enable it, see the [ACL documentation](.
 ```
 :::
 ::: code-group-item JavaScript
-@[code{Enable}](../node/2.0.0/samples/projection-management.js)
+@[code{Enable}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -229,7 +229,7 @@ You must have access to a projection to enable it, see the [ACL documentation](.
 ```
 :::
 ::: code-group-item TypeScript
-@[code{Enable}](../node/2.0.0/samples/projection-management.ts)
+@[code{Enable}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -237,7 +237,7 @@ You can only enable an existing projection. When you try to enable a non-existin
 
 :::: code-group
 ::: code-group-item C#
-@[code{EnableNotFound}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{EnableNotFound}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -250,7 +250,7 @@ You can only enable an existing projection. When you try to enable a non-existin
 ```
 :::
 ::: code-group-item JavaScript
-@[code{EnableNotFound}](../node/2.0.0/samples/projection-management.js)
+@[code{EnableNotFound}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -258,7 +258,7 @@ You can only enable an existing projection. When you try to enable a non-existin
 ```
 :::
 ::: code-group-item TypeScript
-@[code{EnableNotFound}](../node/2.0.0/samples/projection-management.ts)
+@[code{EnableNotFound}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -266,7 +266,7 @@ You can only enable an existing projection. When you try to enable a non-existin
 
 Disables a projection, this will save the projection checkpoint.
 Once disabled, the projection will not process events even after restarting the server or the projection subsystem.
-You must have access to a projection to disable it, see the [ACL documentation](../../server/v21.2/security/acl.md#stream-acl)
+You must have access to a projection to disable it, see the [ACL documentation](../../server/v21.10/security/acl.md#stream-acl)
 
 :::warning
 The .net clients up to version 21.2 had an incorrect behavior: they _will not_ save the checkpoint  
@@ -274,7 +274,7 @@ The .net clients up to version 21.2 had an incorrect behavior: they _will not_ s
 
 :::: code-group
 ::: code-group-item C#
-@[code{Disable}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{Disable}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -287,7 +287,7 @@ The .net clients up to version 21.2 had an incorrect behavior: they _will not_ s
 ```
 :::
 ::: code-group-item JavaScript
-@[code{Disable}](../node/2.0.0/samples/projection-management.js)
+@[code{Disable}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -295,7 +295,7 @@ The .net clients up to version 21.2 had an incorrect behavior: they _will not_ s
 ```
 :::
 ::: code-group-item TypeScript
-@[code{Disable}](../node/2.0.0/samples/projection-management.ts)
+@[code{Disable}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -303,7 +303,7 @@ You can only disable an existing projection. When you try to disable a non-exist
 
 :::: code-group
 ::: code-group-item C#
-@[code{DisableNotFound}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{DisableNotFound}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -316,7 +316,7 @@ You can only disable an existing projection. When you try to disable a non-exist
 ```
 :::
 ::: code-group-item JavaScript
-@[code{DisableNotFound}](../node/2.0.0/samples/projection-management.js)
+@[code{DisableNotFound}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -324,7 +324,7 @@ You can only disable an existing projection. When you try to disable a non-exist
 ```
 :::
 ::: code-group-item TypeScript
-@[code{DisableNotFound}](../node/2.0.0/samples/projection-management.ts)
+@[code{DisableNotFound}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -349,7 +349,7 @@ Deletes a projection
 ```
 :::
 ::: code-group-item JavaScript
-@[code{Delete}](../node/2.0.0/samples/projection-management.js)
+@[code{Delete}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -357,7 +357,7 @@ Deletes a projection
 ```
 :::
 ::: code-group-item TypeScript
-@[code{Delete}](../node/2.0.0/samples/projection-management.ts)
+@[code{Delete}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -380,7 +380,7 @@ You can only delete an existing projection. When you try to delete a non-existin
 ```
 :::
 ::: code-group-item JavaScript
-@[code{DeleteNotFound}](../node/2.0.0/samples/projection-management.js)
+@[code{DeleteNotFound}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -388,7 +388,7 @@ You can only delete an existing projection. When you try to delete a non-existin
 ```
 :::
 ::: code-group-item TypeScript
-@[code{DeleteNotFound}](../node/2.0.0/samples/projection-management.ts)
+@[code{DeleteNotFound}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -402,7 +402,7 @@ The .net clients up to version 21.2 had an incorrect behavior: they _will_ save 
 
 :::: code-group
 ::: code-group-item C#
-@[code{Abort}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{Abort}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -415,7 +415,7 @@ The .net clients up to version 21.2 had an incorrect behavior: they _will_ save 
 ```
 :::
 ::: code-group-item JavaScript
-@[code{Abort}](../node/2.0.0/samples/projection-management.js)
+@[code{Abort}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -423,7 +423,7 @@ The .net clients up to version 21.2 had an incorrect behavior: they _will_ save 
 ```
 :::
 ::: code-group-item TypeScript
-@[code{Abort}](../node/2.0.0/samples/projection-management.ts)
+@[code{Abort}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -431,7 +431,7 @@ You can only abort an existing projection. When you try to abort a non-existing 
 
 :::: code-group
 ::: code-group-item C#
-@[code{Abort_NotFound}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{Abort_NotFound}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -444,7 +444,7 @@ You can only abort an existing projection. When you try to abort a non-existing 
 ```
 :::
 ::: code-group-item JavaScript
-@[code{Abort_NotFound}](../node/2.0.0/samples/projection-management.js)
+@[code{Abort_NotFound}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 
@@ -453,7 +453,7 @@ You can only abort an existing projection. When you try to abort a non-existing 
 ```
 :::
 ::: code-group-item TypeScript
-@[code{Abort_NotFound}](../node/2.0.0/samples/projection-management.ts)
+@[code{Abort_NotFound}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -462,7 +462,7 @@ Resets a projection. This will re-emit events. Streams that are written to from 
 
 :::: code-group
 ::: code-group-item C#
-@[code{Reset}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{Reset}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -475,7 +475,7 @@ Resets a projection. This will re-emit events. Streams that are written to from 
 ```
 :::
 ::: code-group-item JavaScript
-@[code{Reset}](../node/2.0.0/samples/projection-management.js)
+@[code{Reset}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -483,7 +483,7 @@ Resets a projection. This will re-emit events. Streams that are written to from 
 ```
 :::
 ::: code-group-item TypeScript
-@[code{Reset}](../node/2.0.0/samples/projection-management.ts)
+@[code{Reset}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -491,7 +491,7 @@ Resetting a projection that does not exists will result in an error.
 
 :::: code-group
 ::: code-group-item C#
-@[code{Reset_NotFound}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{Reset_NotFound}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -504,7 +504,7 @@ Resetting a projection that does not exists will result in an error.
 ```
 :::
 ::: code-group-item JavaScript
-@[code{Reset_NotFound}](../node/2.0.0/samples/projection-management.js)
+@[code{Reset_NotFound}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 
@@ -513,7 +513,7 @@ Resetting a projection that does not exists will result in an error.
 ```
 :::
 ::: code-group-item TypeScript
-@[code{Reset_NotFound}](../node/2.0.0/samples/projection-management.ts)
+@[code{Reset_NotFound}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -523,7 +523,7 @@ Updates a projection. The name parameter is the name of the projection to be upd
 
 :::: code-group
 ::: code-group-item C#
-@[code{Update}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{Update}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -536,7 +536,7 @@ Updates a projection. The name parameter is the name of the projection to be upd
 ```
 :::
 ::: code-group-item JavaScript
-@[code{Update}](../node/2.0.0/samples/projection-management.js)
+@[code{Update}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -544,7 +544,7 @@ Updates a projection. The name parameter is the name of the projection to be upd
 ```
 :::
 ::: code-group-item TypeScript
-@[code{Update}](../node/2.0.0/samples/projection-management.ts)
+@[code{Update}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -552,7 +552,7 @@ You can only update an existing projection. When you try to update a non-existin
 
 :::: code-group
 ::: code-group-item C#
-@[code{Update_NotFound}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{Update_NotFound}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -565,7 +565,7 @@ You can only update an existing projection. When you try to update a non-existin
 ```
 :::
 ::: code-group-item JavaScript
-@[code{Update_NotFound}](../node/2.0.0/samples/projection-management.js)
+@[code{Update_NotFound}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -573,7 +573,7 @@ You can only update an existing projection. When you try to update a non-existin
 ```
 :::
 ::: code-group-item TypeScript
-@[code{Update_NotFound}](../node/2.0.0/samples/projection-management.ts)
+@[code{Update_NotFound}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -584,7 +584,7 @@ See the [projection details](#projection-details) section for an explanation of 
 
 :::: code-group
 ::: code-group-item C#
-@[code{ListAll}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{ListAll}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -597,7 +597,7 @@ See the [projection details](#projection-details) section for an explanation of 
 ```
 :::
 ::: code-group-item JavaScript
-@[code{ListAll}](../node/2.0.0/samples/projection-management.ts)
+@[code{ListAll}](@grpc:projection-management.ts)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -605,7 +605,7 @@ See the [projection details](#projection-details) section for an explanation of 
 ```
 :::
 ::: code-group-item TypeScript
-@[code{ListAll}](../node/2.0.0/samples/projection-management.ts)
+@[code{ListAll}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -616,7 +616,7 @@ See the [projection details](#projection-details) section for an explanation of 
 
 :::: code-group
 ::: code-group-item C#
-@[code{ListContinuous}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{ListContinuous}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -629,7 +629,7 @@ See the [projection details](#projection-details) section for an explanation of 
 ```
 :::
 ::: code-group-item JavaScript
-@[code{ListContinuous}](../node/2.0.0/samples/projection-management.js)
+@[code{ListContinuous}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -637,7 +637,7 @@ See the [projection details](#projection-details) section for an explanation of 
 ```
 :::
 ::: code-group-item TypeScript
-@[code{ListContinuous}](../node/2.0.0/samples/projection-management.ts)
+@[code{ListContinuous}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -648,7 +648,7 @@ See the [projection details](#projection-details) section for an explanation of 
 
 :::: code-group
 ::: code-group-item C#
-@[code{GetStatus}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{GetStatus}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -661,7 +661,7 @@ See the [projection details](#projection-details) section for an explanation of 
 ```
 :::
 ::: code-group-item JavaScript
-@[code{GetStatus}](../node/2.0.0/samples/projection-management.js)
+@[code{GetStatus}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -669,7 +669,7 @@ See the [projection details](#projection-details) section for an explanation of 
 ```
 :::
 ::: code-group-item TypeScript
-@[code{GetStatus}](../node/2.0.0/samples/projection-management.ts)
+@[code{GetStatus}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -694,7 +694,7 @@ Sample available soon
 ```
 :::
 ::: code-group-item JavaScript
-@[code{GetState}](../node/2.0.0/samples/projection-management.js)
+@[code{GetState}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -702,7 +702,7 @@ Sample available soon
 ```
 :::
 ::: code-group-item TypeScript
-@[code{GetState}](../node/2.0.0/samples/projection-management.ts)
+@[code{GetState}](@grpc:projection-management.ts)
 :::
 ::::
 
@@ -712,7 +712,7 @@ Retrieves the result of the named projection and partition.
 
 :::: code-group
 ::: code-group-item C#
-@[code{GetResult}](../dotnet/21.6/samples/projection-management/Program.cs)
+@[code{GetResult}](@grpc:projection-management/Program.cs)
 :::
 ::: code-group-item Go
 ```Go
@@ -725,7 +725,7 @@ Sample available soon
 ```
 :::
 ::: code-group-item JavaScript
-@[code{GetResult}](../node/2.0.0/samples/projection-management.js)
+@[code{GetResult}](@grpc:projection-management.js)
 :::
 ::: code-group-item Rust
 ```Rust
@@ -733,7 +733,7 @@ Sample available soon
 ```
 :::
 ::: code-group-item TypeScript
-@[code{GetResult}](../node/2.0.0/samples/projection-management.ts)
+@[code{GetResult}](@grpc:projection-management.ts)
 :::
 ::::
 

--- a/docs/clients/grpc/reading-events.md
+++ b/docs/clients/grpc/reading-events.md
@@ -18,11 +18,11 @@ You can read events from individual streams, both all the events, or just a few 
 
 The simplest way to read a stream forwards is to supply a stream name, direction and revision to start from. This can either be a *stream position* `Start` or a *big int* (unsigned 64-bit integer):
 
-@[code{read-from-stream}](@grpc/reading-events/Program.cs;@grpc/readingEvents.go;@grpc/reading_events/ReadingEvents.java;@grpc/reading-events.js;@grpc/reading_events.rs;@grpc/reading-events.ts)
+@[code{read-from-stream}](@grpc:reading-events/Program.cs;readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
 
 This will return an enumerable that can be iterated on:
 
-@[code{iterate-stream}](@grpc/reading-events/Program.cs;@grpc/readingEvents.go;@grpc/reading_events/ReadingEvents.java;@grpc/reading-events.js;@grpc/reading_events.rs;@grpc/reading-events.ts)
+@[code{iterate-stream}](@grpc:reading-events/Program.cs;readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
 
 There are a number of additional arguments you can provide when reading a stream, listed below.
 
@@ -42,76 +42,19 @@ You can use the `configureOperationOptions` argument to provide a function that 
 
 The `userCredentials` argument is optional. You can use it to override the default credentials specified when creating the client instance.
 
-:::: code-group
-::: code-group-item C#
-@[code{overriding-user-credentials}](@grpc/reading-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{overriding-user-credentials}](@grpc/readingEvents.go)
-:::
-::: code-group-item Java
-@[code{overriding-user-credentials}](@grpc/reading_events/ReadingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{overriding-user-credentials}](@grpc/reading-events.js)
-:::
-::: code-group-item Rust
-@[code{overriding-user-credentials}](@grpc/reading_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{overriding-user-credentials}](@grpc/reading-events.ts)
-:::
-::::
+@[code{overriding-user-credentials}](@grpc:reading-events/Program.cs;readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
 
 ### Reading from a revision
 
 Instead of providing the `StreamPosition` you can also provide a specific stream revision as a *big int* (unsigned 64-bit integer).
 
-:::: code-group
-::: code-group-item C#
-@[code{read-from-stream-position}](../dotnet/21.2/samples/reading-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{read-from-stream-position}](../go/1.0.0/samples/readingEvents.go)
-:::
-::: code-group-item Java
-@[code{read-from-stream-position}](../java/1.0.0/samples/reading_events/ReadingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{read-from-stream-position}](../node/2.0.0/samples/reading-events.js)
-:::
-::: code-group-item Rust
-@[code{read-from-position}](../rust/1.0.0/samples/reading_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{read-from-stream-position}](../node/2.0.0/samples/reading-events.ts)
-:::
-::::
+@[code{read-from-stream-position}](@grpc:reading-events/Program.cs;/readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
 
 ### Reading backwards
 
 As well as being able to read a stream forwards you can also go backwards. When reading backwards, you need to set the *stream position* the end if you want to read all the events:
 
-:::: code-group
-::: code-group-item C#
-@[code{reading-backwards}](../dotnet/21.2/samples/reading-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{reading-backwards}](../go/1.0.0/samples/readingEvents.go)
-:::
-::: code-group-item Java
-@[code{reading-backwards}](../java/1.0.0/samples/reading_events/ReadingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{reading-backwards}](../node/2.0.0/samples/reading-events.js)
-:::
-::: code-group-item Rust
-@[code{reading-backwards}](../rust/1.0.0/samples/reading_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{reading-backwards}](../node/2.0.0/samples/reading-events.ts)
-:::
-::::
+@[code{reading-backwards}](@grpc:reading-events/Program.cs;readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
 
 :::tip
 You can use reading backwards to find the last position in the stream. Just read backwards one event and get the position.
@@ -125,26 +68,7 @@ It is important to check the value of this field before attempting to iterate an
 
 For example:
 
-:::: code-group
-::: code-group-item C#
-@[code{checking-for-stream-presence}](../dotnet/21.2/samples/reading-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{checking-for-stream-presence}](../go/1.0.0/samples/readingEvents.go)
-:::
-::: code-group-item Java
-@[code{checking-for-stream-presence}](../java/1.0.0/samples/reading_events/ReadingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{checking-for-stream-presence}](../node/2.0.0/samples/reading-events.js)
-:::
-::: code-group-item Rust
-@[code{checking-for-stream-presence}](../rust/1.0.0/samples/reading_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{checking-for-stream-presence}](../node/2.0.0/samples/reading-events.ts)
-:::
-::::
+@[code{checking-for-stream-presence}](@grpc:reading-events/Program.cs;readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
 
 ## Reading from the $all stream
 
@@ -154,31 +78,11 @@ Reading from the all stream is similar to reading from an individual stream but 
 
 The simplest way to read the `$all` stream forwards is to supply a direction and transaction log position to start from. This can either be a *stream position* `Start` or a *big int* (unsigned 64-bit integer):
 
-:::: code-group
-::: code-group-item C#
-@[code{read-from-all-stream}](../dotnet/21.2/samples/reading-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{read-from-all-stream}](../go/1.0.0/samples/readingEvents.go)
-:::
-::: code-group-item Java
-@[code{read-from-all-stream}](../java/1.0.0/samples/reading_events/ReadingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{read-from-all-stream}](../node/2.0.0/samples/reading-events.js)
-:::
-::: code-group-item Rust
-@[code{read-from-all-stream}](../rust/1.0.0/samples/reading_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{read-from-all-stream}](../node/2.0.0/samples/reading-events.ts)
-:::
-::::
-
+@[code{read-from-all-stream}](@grpc:reading-events/Program.cs;readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
 
 You can iterate asynchronously through the result:
 
-@[code{read-from-all-stream-iterate}](@grpc/reading-events/Program.cs;@grpc/readingEvents.go;@grpc/reading_events/ReadingEvents.java;@grpc/reading-events.js;@grpc/reading_events.rs;@grpc/reading-events.ts)
+@[code{read-from-all-stream-iterate}](@grpc:reading-events/Program.cs;readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
 
 There are a number of additional arguments you can provide when reading a stream.
 
@@ -190,26 +94,8 @@ Passing in the max count allows you to limit the number of events that returned.
 
 When using projections to create new events you can set whether the generated events are pointers to existing events. Setting this value to true will tell EventStoreDB to return the event as well as the event linking to it.
 
-:::: code-group
-::: code-group-item C#
-@[code{read-from-all-stream-resolving-link-Tos}](../dotnet/21.2/samples/reading-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{read-from-all-stream-resolving-link-Tos}](../go/1.0.0/samples/readingEvents.go)
-:::
-::: code-group-item Java
-@[code{read-from-all-stream-resolving-link-Tos}](../java/1.0.0/samples/reading_events/ReadingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{read-from-all-stream-resolving-link-Tos}](../node/2.0.0/samples/reading-events.js)
-:::
-::: code-group-item Rust
-@[code{read-from-all-stream-resolving-link-Tos}](../rust/1.0.0/samples/reading_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{read-from-all-stream-resolving-link-Tos}](../node/2.0.0/samples/reading-events.ts)
-:::
-::::
+
+@[code{read-from-all-stream-resolving-link-Tos}](@grpc:reading-events/Program.cs;readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
 
 #### configureOperationOptions
 
@@ -218,51 +104,13 @@ This argument is generic setting class for all operations that can be set on all
 #### userCredentials
 The credentials used to read the data can be supplied. to be used by the subscription as follows. This will override the default credentials set on the connection.
 
-:::: code-group
-::: code-group-item C#
-@[code{read-all-overriding-user-credentials}](../dotnet/21.2/samples/reading-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{read-all-overriding-user-credentials}](../go/1.0.0/samples/readingEvents.go)
-:::
-::: code-group-item Java
-@[code{read-all-overriding-user-credentials}](../java/1.0.0/samples/reading_events/ReadingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{read-all-overriding-user-credentials}](../node/2.0.0/samples/reading-events.js)
-:::
-::: code-group-item Rust
-@[code{read-all-overriding-user-credentials}](../rust/1.0.0/samples/reading_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{read-all-overriding-user-credentials}](../node/2.0.0/samples/reading-events.ts)
-:::
-::::
+@[code{read-all-overriding-user-credentials}](@grpc:reading-events/Program.cs;readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
 
 ### Reading backwards
 
 As well as being able to read a stream forwards you can also go backwards. When reading backwards is the *position* will have to be set to the end if you want to read all the events:
 
-:::: code-group
-::: code-group-item C#
-@[code{read-from-all-stream-backwards}](../dotnet/21.2/samples/reading-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{read-from-all-stream-backwards}](../go/1.0.0/samples/readingEvents.go)
-:::
-::: code-group-item Java
-@[code{read-from-all-stream-backwards}](../java/1.0.0/samples/reading_events/ReadingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{read-from-all-stream-backwards}](../node/2.0.0/samples/reading-events.js)
-:::
-::: code-group-item Rust
-@[code{read-from-all-stream-backwards}](../rust/1.0.0/samples/reading_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{read-from-all-stream-backwards}](../node/2.0.0/samples/reading-events.ts)
-:::
-::::
+@[code{read-from-all-stream-backwards}](@grpc:reading-events/Program.cs;readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
 
 :::tip
 You can use reading backwards to find the last position in the stream. Just read backwards one event and get the position.
@@ -274,23 +122,5 @@ When reading from the all stream EventStoreDB will also return system events. In
 
 All system events begin with `$` or `$$` and can be easily ignored by checking the `EventType` property.
 
-:::: code-group
-::: code-group-item C#
-@[code{ignore-system-events}](../dotnet/21.2/samples/reading-events/Program.cs)
-:::
-::: code-group-item Go
-@[code{ignore-system-events}](../go/1.0.0/samples/readingEvents.go)
-:::
-::: code-group-item Java
-@[code{ignore-system-events}](../java/1.0.0/samples/reading_events/ReadingEvents.java)
-:::
-::: code-group-item JavaScript
-@[code{ignore-system-events}](../node/2.0.0/samples/reading-events.js)
-:::
-::: code-group-item Rust
-@[code{ignore-system-events}](../rust/1.0.0/samples/reading_events.rs)
-:::
-::: code-group-item TypeScript
-@[code{ignore-system-events}](../node/2.0.0/samples/reading-events.ts)
-:::
-::::
+@[code{ignore-system-events}](@grpc:reading-events/Program.cs;readingEvents.go;reading_events/ReadingEvents.java;reading-events.js;reading_events.rs;reading-events.ts)
+

--- a/docs/clients/grpc/subscriptions.md
+++ b/docs/clients/grpc/subscriptions.md
@@ -14,26 +14,7 @@ Check [connecting to EventStoreDB instructions](./README.md#required-packages) t
 
 The simplest stream subscription looks like the following :
 
-:::: code-group
-::: code-group-item C#
-@[code{subscribe-to-stream}](../dotnet/21.2/samples/subscribing-to-streams/Program.cs)
-:::
-::: code-group-item Go
-@[code{subscribe-to-stream}](../go/1.0.0/samples/subscribingToStream.go)
-:::
-::: code-group-item Java
-@[code{subscribe-to-stream}](../java/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java)
-:::
-::: code-group-item JavaScript
-@[code{subscribe-to-stream}](../node/2.0.0/samples/subscribing-to-streams.js)
-:::
-::: code-group-item Rust
-@[code{subscribe-to-stream}](../rust/1.0.0/samples/subscribing_to_stream.rs)
-:::
-::: code-group-item TypeScript
-@[code{subscribe-to-stream}](../node/2.0.0/samples/subscribing-to-streams.ts)
-:::
-::::
+@[code{subscribe-to-stream}](@grpc:subscribing-to-streams/Program.cs;subscribingToStream.go;subscribing_to_stream/SubscribingToStream.java;subscribing-to-streams.js;subscribing_to_stream.rs;subscribing-to-streams.ts)
 
 The provided handler will be called for every event in the stream.
 
@@ -61,26 +42,7 @@ To subscribe to a stream from a specific position, you need to provide a *stream
 
 The following subscribes to the stream `some-stream` at position `20`, this means that events `21` and onward will be handled:
 
-:::: code-group
-::: code-group-item C#
-@[code{subscribe-to-stream-from-position}](@grpc/subscribing-to-streams/Program.cs)
-:::
-::: code-group-item Go
-@[code{subscribe-to-stream-from-position}](../go/1.0.0/samples/subscribingToStream.go)
-:::
-::: code-group-item Java
-@[code{subscribe-to-stream-from-position}](../java/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java)
-:::
-::: code-group-item JavaScript
-@[code{subscribe-to-stream-from-position}](../node/2.0.0/samples/subscribing-to-streams.js)
-:::
-::: code-group-item Rust
-@[code{subscribe-to-stream-from-position}](../rust/1.0.0/samples/subscribing_to_stream.rs)
-:::
-::: code-group-item TypeScript
-@[code{subscribe-to-stream-from-position}](../node/2.0.0/samples/subscribing-to-streams.ts)
-:::
-::::
+@[code{subscribe-to-stream-from-position}](@grpc:subscribing-to-streams/Program.cs;subscribingToStream.go;subscribing_to_stream/SubscribingToStream.java;subscribing-to-streams.js;subscribing_to_stream.rs;subscribing-to-streams.ts)
 
 ### Subscribing to $all
 
@@ -90,74 +52,17 @@ The corresponding `$all` subscription will subscribe from the event after the on
 
 Please note that this position will need to be a legitimate position in `$all`.
 
-:::: code-group
-::: code-group-item C#
-@[code{subscribe-to-all-from-position}](@grpc/subscribing-to-streams/Program.cs)
-:::
-::: code-group-item Go
-@[code{subscribe-to-all-from-position}](../go/1.0.0/samples/subscribingToStream.go)
-:::
-::: code-group-item Java
-@[code{subscribe-to-all-from-position}](../java/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java)
-:::
-::: code-group-item JavaScript
-@[code{subscribe-to-all-from-position}](../node/2.0.0/samples/subscribing-to-streams.js)
-:::
-::: code-group-item Rust
-@[code{subscribe-to-all-from-position}](../rust/1.0.0/samples/subscribing_to_stream.rs)
-:::
-::: code-group-item TypeScript
-@[code{subscribe-to-all-from-position}](../node/2.0.0/samples/subscribing-to-streams.ts)
-:::
-::::
+@[code{subscribe-to-all-from-position}](@grpc:subscribing-to-streams/Program.cs;subscribingToStream.go;subscribing_to_stream/SubscribingToStream.java;subscribing-to-streams.js;subscribing_to_stream.rs;subscribing-to-streams.ts)
 
 ## Subscribing to a stream for live updates
 
 You can subscribe to a stream to get live updates by subscribing to the end of the stream:
 
-:::: code-group
-::: code-group-item C#
-@[code{subscribe-to-stream-live}](@grpc/subscribing-to-streams/Program.cs)
-:::
-::: code-group-item Go
-@[code{subscribe-to-stream-live}](../go/1.0.0/samples/subscribingToStream.go)
-:::
-::: code-group-item Java
-@[code{subscribe-to-stream-live}](../java/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java)
-:::
-::: code-group-item JavaScript
-@[code{subscribe-to-stream-live}](../node/2.0.0/samples/subscribing-to-streams.js)
-:::
-::: code-group-item Rust
-@[code{subscribe-to-stream-live}](../rust/1.0.0/samples/subscribing_to_stream.rs)
-:::
-::: code-group-item TypeScript
-@[code{subscribe-to-stream-live}](../node/2.0.0/samples/subscribing-to-streams.ts)
-:::
-::::
+@[code{subscribe-to-stream-live}](@grpc:subscribing-to-streams/Program.cs;subscribingToStream.go;subscribing_to_stream/SubscribingToStream.java;subscribing-to-streams.js;subscribing_to_stream.rs;subscribing-to-streams.ts)
 
 And the same works with `$all` :
 
-:::: code-group
-::: code-group-item C#
-@[code{subscribe-to-all-live}](@grpc/subscribing-to-streams/Program.cs)
-:::
-::: code-group-item Go
-@[code{subscribe-to-all-live}](../go/1.0.0/samples/subscribingToStream.go)
-:::
-::: code-group-item Java
-@[code{subscribe-to-all-live}](../java/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java)
-:::
-::: code-group-item JavaScript
-@[code{subscribe-to-all-live}](../node/2.0.0/samples/subscribing-to-streams.js)
-:::
-::: code-group-item Rust
-@[code{subscribe-to-all-live}](../rust/1.0.0/samples/subscribing_to_stream.rs)
-:::
-::: code-group-item TypeScript
-@[code{subscribe-to-all-live}](../node/2.0.0/samples/subscribing-to-streams.ts)
-:::
-::::
+@[code{subscribe-to-all-live}](@grpc:subscribing-to-streams/Program.cs;subscribingToStream.go;subscribing_to_stream/SubscribingToStream.java;subscribing-to-streams.js;subscribing_to_stream.rs;subscribing-to-streams.ts)
 
 This won't read through the history of the stream, but will rather notify the handler when a new event appears in the respective stream.
 
@@ -173,26 +78,7 @@ Link-to events point to events in other streams in EventStoreDB. These are gener
 
 When reading a stream you can specify whether to resolve link-to's or not. By default, link-to events are not resolved. You can change this behaviour by setting the `resolveLinkTos` parameter to `true`:
 
-:::: code-group
-::: code-group-item C#
-@[code{subscribe-to-stream-resolving-linktos}](@grpc/subscribing-to-streams/Program.cs)
-:::
-::: code-group-item Go
-@[code{subscribe-to-stream-resolving-linktos}](../go/1.0.0/samples/subscribingToStream.go)
-:::
-::: code-group-item Java
-@[code{subscribe-to-stream-resolving-linktos}](../java/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java)
-:::
-::: code-group-item JavaScript
-@[code{subscribe-to-stream-resolving-linktos}](../node/2.0.0/samples/subscribing-to-streams.js)
-:::
-::: code-group-item Rust
-@[code{subscribe-to-stream-resolving-linktos}](../rust/1.0.0/samples/subscribing_to_stream.rs)
-:::
-::: code-group-item TypeScript
-@[code{subscribe-to-stream-resolving-linktos}](../node/2.0.0/samples/subscribing-to-streams.ts)
-:::
-::::
+@[code{subscribe-to-stream-resolving-linktos}](@grpc:subscribing-to-streams/Program.cs;subscribingToStream.go;subscribing_to_stream/SubscribingToStream.java;subscribing-to-streams.js;subscribing_to_stream.rs;subscribing-to-streams.ts)
 
 ## Dropped subscriptions
 
@@ -214,49 +100,11 @@ Bear in mind that a subscription can also drop because it is slow. The server tr
 
 An application, which hosts the subscription, can go offline for a period of time for different reasons. It could be a crash, infrastructure failure, or a new version deployment. As you rarely would want to reprocess all the events again, you'd need to store the current position of the subscription somewhere, and then use it to restore the subscription from the point where it dropped off:
 
-:::: code-group
-::: code-group-item C#
-@[code{subscribe-to-stream-subscription-dropped}](@grpc/subscribing-to-streams/Program.cs)
-:::
-::: code-group-item Go
-@[code{subscribe-to-stream-subscription-dropped}](../go/1.0.0/samples/subscribingToStream.go)
-:::
-::: code-group-item Java
-@[code{subscribe-to-stream-subscription-dropped}](../java/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java)
-:::
-::: code-group-item JavaScript
-@[code{subscribe-to-stream-subscription-dropped}](../node/2.0.0/samples/subscribing-to-streams.js)
-:::
-::: code-group-item Rust
-@[code{subscribe-to-stream-subscription-dropped}](../rust/1.0.0/samples/subscribing_to_stream.rs)
-:::
-::: code-group-item TypeScript
-@[code{subscribe-to-stream-subscription-dropped}](../node/2.0.0/samples/subscribing-to-streams.ts)
-:::
-::::
+@[code{subscribe-to-stream-subscription-dropped}](@grpc:subscribing-to-streams/Program.cs;subscribingToStream.go;subscribing_to_stream/SubscribingToStream.java;subscribing-to-streams.js;subscribing_to_stream.rs;subscribing-to-streams.ts)
 
 When subscribed to `$all` you want to keep the position of the event in the `$all` stream. As mentioned previously, the `$all` stream position consists of two big integers (prepare and commit positions), not one:
 
-:::: code-group
-::: code-group-item C#
-@[code{subscribe-to-all-subscription-dropped}](@grpc/subscribing-to-streams/Program.cs)
-:::
-::: code-group-item Go
-@[code{subscribe-to-all-subscription-dropped}](../go/1.0.0/samples/subscribingToStream.go)
-:::
-::: code-group-item Java
-@[code{subscribe-to-all-subscription-dropped}](../java/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java)
-:::
-::: code-group-item JavaScript
-@[code{subscribe-to-all-subscription-dropped}](../node/2.0.0/samples/subscribing-to-streams.js)
-:::
-::: code-group-item Rust
-@[code{subscribe-to-all-subscription-dropped}](../rust/1.0.0/samples/subscribing_to_stream.rs)
-:::
-::: code-group-item TypeScript
-@[code{subscribe-to-all-subscription-dropped}](../node/2.0.0/samples/subscribing-to-streams.ts)
-:::
-::::
+@[code{subscribe-to-all-subscription-dropped}](@grpc:subscribing-to-streams/Program.cs;subscribingToStream.go;subscribing_to_stream/SubscribingToStream.java;subscribing-to-streams.js;subscribing_to_stream.rs;subscribing-to-streams.ts)
 
 ## Filter options
 
@@ -264,26 +112,7 @@ Subscriptions to `$all` can include a filter option. A filtered subscription wil
 
 A simple stream prefix filter looks like this:
 
-:::: code-group
-::: code-group-item C#
-@[code{stream-prefix-filtered-subscription}](@grpc/subscribing-to-streams/Program.cs)
-:::
-::: code-group-item Go
-@[code{stream-prefix-filtered-subscription}](../go/1.0.0/samples/subscribingToStream.go)
-:::
-::: code-group-item Java
-@[code{stream-prefix-filtered-subscription}](../java/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java)
-:::
-::: code-group-item JavaScript
-@[code{stream-prefix-filtered-subscription}](../node/2.0.0/samples/subscribing-to-streams.js)
-:::
-::: code-group-item Rust
-@[code{stream-prefix-filtered-subscription}](../rust/1.0.0/samples/subscribing_to_stream.rs)
-:::
-::: code-group-item TypeScript
-@[code{stream-prefix-filtered-subscription}](../node/2.0.0/samples/subscribing-to-streams.ts)
-:::
-::::
+@[code{stream-prefix-filtered-subscription}](@grpc:subscribing-to-streams/Program.cs;subscribingToStream.go;subscribing_to_stream/SubscribingToStream.java;subscribing-to-streams.js;subscribing_to_stream.rs;subscribing-to-streams.ts)
 
 The filtering API is described more in-depth in the [filtering section](./subscriptions.md#filter-options).
 
@@ -293,26 +122,7 @@ The user creating a subscription must have read access to the stream it's subscr
 
 The code below shows how you can provide user credentials for a subscription. When you specify subscription credentials explicitly, it will override the default credentials set for the client. If you don't specify any credentials, the client will use the credentials specified for the client, if you specified those.
 
-:::: code-group
-::: code-group-item C#
-@[code{overriding-user-credentials}](@grpc/subscribing-to-streams/Program.cs)
-:::
-::: code-group-item Go
-@[code{overriding-user-credentials}](../go/1.0.0/samples/subscribingToStream.go)
-:::
-::: code-group-item Java
-@[code{overriding-user-credentials}](../java/1.0.0/samples/subscribing_to_stream/SubscribingToStream.java)
-:::
-::: code-group-item JavaScript
-@[code{overriding-user-credentials}](../node/2.0.0/samples/subscribing-to-streams.js)
-:::
-::: code-group-item Rust
-@[code{overriding-user-credentials}](../rust/1.0.0/samples/subscribing_to_stream.rs)
-:::
-::: code-group-item TypeScript
-@[code{overriding-user-credentials}](../node/2.0.0/samples/subscribing-to-streams.ts)
-:::
-::::
+@[code{overriding-user-credentials}](@grpc:subscribing-to-streams/Program.cs;subscribingToStream.go;subscribing_to_stream/SubscribingToStream.java;subscribing-to-streams.js;subscribing_to_stream.rs;subscribing-to-streams.ts)
 
 # Server-side filtering
 
@@ -328,26 +138,7 @@ Server-side filtering introduced as a simpler alternative to projections. Before
 
 There are a number of events in EventStoreDB called system events. These are prefixed with a `$` and under most circumstances you won't care about these. They can be filtered out by passing in a `SubscriptionFilterOptions` when subscribing to the `$all` stream.
 
-:::: code-group
-::: code-group-item C#
-@[code{exclude-system}](@grpc/server-side-filtering/Program.cs)
-:::
-::: code-group-item Go
-@[code{exclude-system}](../go/1.0.0/samples/serverSideFiltering.go)
-:::
-::: code-group-item Java
-@[code{exclude-system}](../java/1.0.0/samples/server_side_filtering/ServerSideFiltering.java)
-:::
-::: code-group-item JavaScript
-@[code{exclude-system}](../node/2.0.0/samples/server-side-filtering.js)
-:::
-::: code-group-item Rust
-@[code{exclude-system}](../rust/1.0.0/samples/server_side_filtering.rs)
-:::
-::: code-group-item TypeScript
-@[code{exclude-system}](../node/2.0.0/samples/server-side-filtering.ts)
-:::
-::::
+@[code{exclude-system}](@grpc:server-side-filtering/Program.cs;serverSideFiltering.go;server_side_filtering/ServerSideFiltering.java;server-side-filtering.js;server_side_filtering.rs;server-side-filtering.ts)
 
 ::: tip
 `$stats` events are no longer stored in EventStoreDB by default so there won't be as many `$` events as before.
@@ -361,26 +152,7 @@ If you only want to subscribe to events of a given type there are two options. Y
 
 If you want to filter by prefix pass in a `SubscriptionFilterOptions` to the subscription with an `EventTypeFilter.Prefix`.
 
-:::: code-group
-::: code-group-item C#
-@[code{event-type-prefix}](@grpc/server-side-filtering/Program.cs)
-:::
-::: code-group-item Go
-@[code{event-type-prefix}](../go/1.0.0/samples/serverSideFiltering.go)
-:::
-::: code-group-item Java
-@[code{event-type-prefix}](../java/1.0.0/samples/server_side_filtering/ServerSideFiltering.java)
-:::
-::: code-group-item JavaScript
-@[code{event-type-prefix}](../node/2.0.0/samples/server-side-filtering.js)
-:::
-::: code-group-item Rust
-@[code{event-type-prefix}](../rust/1.0.0/samples/server_side_filtering.rs)
-:::
-::: code-group-item TypeScript
-@[code{event-type-prefix}](../node/2.0.0/samples/server-side-filtering.ts)
-:::
-::::
+@[code{event-type-prefix}](@grpc:server-side-filtering/Program.cs;serverSideFiltering.go;server_side_filtering/ServerSideFiltering.java;server-side-filtering.js;server_side_filtering.rs;server-side-filtering.ts)
 
 This will only subscribe to events with a type that begin with `customer-`.
 
@@ -388,26 +160,7 @@ This will only subscribe to events with a type that begin with `customer-`.
 
 If you want to subscribe to multiple event types then it might be better to provide a regular expression.
 
-:::: code-group
-::: code-group-item C#
-@[code{event-type-regex}](@grpc/server-side-filtering/Program.cs)
-:::
-::: code-group-item Go
-@[code{event-type-regex}](../go/1.0.0/samples/serverSideFiltering.go)
-:::
-::: code-group-item Java
-@[code{event-type-regex}](../java/1.0.0/samples/server_side_filtering/ServerSideFiltering.java)
-:::
-::: code-group-item JavaScript
-@[code{event-type-regex}](../node/2.0.0/samples/server-side-filtering.js)
-:::
-::: code-group-item Rust
-@[code{event-type-regex}](../rust/1.0.0/samples/server_side_filtering.rs)
-:::
-::: code-group-item TypeScript
-@[code{event-type-regex}](../node/2.0.0/samples/server-side-filtering.ts)
-:::
-::::
+@[code{event-type-regex}](@grpc:server-side-filtering/Program.cs;serverSideFiltering.go;server_side_filtering/ServerSideFiltering.java;server-side-filtering.js;server_side_filtering.rs;server-side-filtering.ts)
 
 This will subscribe to any event that begins with `user` or `company`.
 
@@ -419,26 +172,7 @@ If you only want to subscribe to streams with a given name there are two options
 
 If you want to filter by prefix pass in a `SubscriptionFilterOptions` to the subscription with an `StreamFilter.Prefix`.
 
-:::: code-group
-::: code-group-item C#
-@[code{stream-prefix}](@grpc/server-side-filtering/Program.cs)
-:::
-::: code-group-item Go
-@[code{stream-prefix}](../go/1.0.0/samples/serverSideFiltering.go)
-:::
-::: code-group-item Java
-@[code{stream-prefix}](../java/1.0.0/samples/server_side_filtering/ServerSideFiltering.java)
-:::
-::: code-group-item JavaScript
-@[code{stream-prefix}](../node/2.0.0/samples/server-side-filtering.js)
-:::
-::: code-group-item Rust
-@[code{stream-prefix}](../rust/1.0.0/samples/server_side_filtering.rs)
-:::
-::: code-group-item TypeScript
-@[code{stream-prefix}](../node/2.0.0/samples/server-side-filtering.ts)
-:::
-::::
+@[code{stream-prefix}](@grpc:server-side-filtering/Program.cs;serverSideFiltering.go;server_side_filtering/ServerSideFiltering.java;server-side-filtering.js;server_side_filtering.rs;server-side-filtering.ts)
 
 This will only subscribe to streams with a name that begin with `user-`.
 
@@ -446,26 +180,7 @@ This will only subscribe to streams with a name that begin with `user-`.
 
 If you want to subscribe to multiple streams then it might be better to provide a regular expression.
 
-:::: code-group
-::: code-group-item C#
-@[code{stream-regex}](@grpc/server-side-filtering/Program.cs)
-:::
-::: code-group-item Go
-@[code{stream-regex}](../go/1.0.0/samples/serverSideFiltering.go)
-:::
-::: code-group-item Java
-@[code{stream-regex}](../java/1.0.0/samples/server_side_filtering/ServerSideFiltering.java)
-:::
-::: code-group-item JavaScript
-@[code{stream-regex}](../node/2.0.0/samples/server-side-filtering.js)
-:::
-::: code-group-item Rust
-@[code{stream-regex}](../rust/1.0.0/samples/server_side_filtering.rs)
-:::
-::: code-group-item TypeScript
-@[code{stream-regex}](../node/2.0.0/samples/server-side-filtering.ts)
-:::
-::::
+@[code{stream-regex}](@grpc:server-side-filtering/Program.cs;serverSideFiltering.go;server_side_filtering/ServerSideFiltering.java;server-side-filtering.js;server_side_filtering.rs;server-side-filtering.ts)
 
 This will subscribe to any stream with a name that begins with `account` or `savings`.
 
@@ -477,50 +192,11 @@ In this case you can make use of an additional delegate that will be triggered e
 
 To make use of it set up `checkpointReached` on the `SubscriptionFilterOptions` class.
 
-:::: code-group
-::: code-group-item C#
-@[code{checkpoint}](@grpc/server-side-filtering/Program.cs)
-:::
-::: code-group-item Go
-@[code{checkpoint}](../go/1.0.0/samples/serverSideFiltering.go)
-:::
-::: code-group-item Java
-@[code{checkpoint}](../java/1.0.0/samples/server_side_filtering/ServerSideFiltering.java)
-:::
-::: code-group-item JavaScript
-@[code{checkpoint}](../node/2.0.0/samples/server-side-filtering.js)
-:::
-::: code-group-item Rust
-@[code{checkpoint}](../rust/1.0.0/samples/server_side_filtering.rs)
-:::
-::: code-group-item TypeScript
-@[code{checkpoint}](../node/2.0.0/samples/server-side-filtering.ts)
-:::
-::::
+@[code{checkpoint}](@grpc:server-side-filtering/Program.cs;serverSideFiltering.go;server_side_filtering/ServerSideFiltering.java;server-side-filtering.js;server_side_filtering.rs;server-side-filtering.ts)
 
 This will be called every `n` number of events. If you want to be specific about the number of events threshold you can also pass that as a parameter.
 
-:::: code-group
-::: code-group-item C#
-@[code{checkpoint-with-interval}](@grpc/server-side-filtering/Program.cs)
-:::
-::: code-group-item Go
-@[code{checkpoint-with-interval}](../go/1.0.0/samples/serverSideFiltering.go)
-:::
-::: code-group-item Java
-@[code{checkpoint-with-interval}](../java/1.0.0/samples/server_side_filtering/ServerSideFiltering.java)
-:::
-::: code-group-item JavaScript
-@[code{checkpoint-with-interval}](../node/2.0.0/samples/server-side-filtering.js)
-:::
-::: code-group-item Rust
-@[code{checkpoint-with-interval}](../rust/1.0.0/samples/server_side_filtering.rs)
-:::
-::: code-group-item TypeScript
-@[code{checkpoint-with-interval}](../node/2.0.0/samples/server-side-filtering.ts)
-:::
-::::
-
+@[code{checkpoint-with-interval}](@grpc:server-side-filtering/Program.cs;serverSideFiltering.go;server_side_filtering/ServerSideFiltering.java;server-side-filtering.js;server_side_filtering.rs;server-side-filtering.ts)
 ::: warning
 This number will be called every `n * 32` events.
 :::


### PR DESCRIPTION
The issue was that the paths were wrongly resolved. They were referring to wrong versions of the client, see, e.g. https://github.com/EventStore/documentation/pull/507/files#diff-75ae193849ba302fe63e3f3d63c04eaf48d96392c1d13be88c6f5b32a3eeb5baL140. I applied convention-based path resolution by adding `@grpc` (configured in https://github.com/EventStore/documentation/blob/master/docs/.vuepress/samples.ts#L28). Thanks to that version will be automatically resolved to the proper one.

See also:
- https://github.com/EventStore/EventStoreDB-Client-Rust/pull/129
- https://github.com/EventStore/EventStore-Client-Go/pull/102