### PR TITLE
Header alignment and Algolia fixes

### DIFF
--- a/.algolia/config.json
+++ b/.algolia/config.json
@@ -4,16 +4,16 @@
     {
       "url": "http://localhost:8080/server/(?P<version>.*?)/",
       "variables": {
-        "version": ["v20.10"]
+        "version": ["v21.10"]
       },
       "page_rank": 10
     },
     {
       "url": "http://localhost:8080/server/(?P<version>.*?)/",
       "variables": {
-        "version": ["v21.2", "v21.6"]
+        "version": ["v20.10"]
       },
-      "page_rank": 8
+      "page_rank": 6
     },
     {
       "url": "http://localhost:8080/server/(?P<version>.*?)/",
@@ -24,32 +24,26 @@
     },
     {
       "url": "http://localhost:8080/clients/grpc/",
-      "selectors_key": "flat",
       "page_rank": 10
     },
     {
       "url": "http://localhost:8080/clients/http-api/v5/",
-      "selectors_key": "flat",
       "page_rank": 6
     },
     {
       "url": "http://localhost:8080/clients/dotnet/5.0/",
-      "selectors_key": "flat",
       "page_rank": 1
     },
     {
       "url": "http://localhost:8080/clients/dotnet/20.10/",
-      "selectors_key": "flat",
       "page_rank": 3
     },
     {
       "url": "http://localhost:8080/clients/dotnet/21.2/",
-      "selectors_key": "flat",
-      "page_rank": 6
+      "page_rank": 5
     },
     {
       "url": "http://localhost:8080/cloud/",
-      "selectors_key": "flat",
       "page_rank": 10
     }
   ],
@@ -57,54 +51,15 @@
     "default": {
       "lvl0": ".sidebar h4.version",
       "lvl1": {
-        "selector": ".sidebar-heading.active",
-        "global": true,
-        "default_value": "Documentation"
-      },
-      "lvl2": {
         "selector": ".sidebar-heading.active+ul li a.active",
         "strip_chars": "#"
       },
-      "lvl3": {
-        "selector": ".sidebar-heading.active+ul li ul li a.active",
-        "strip_chars": "#"
-      },
-      "lvl4": {
-        "selector": ".theme-default-content h1",
-        "strip_chars": "#"
-      },
-      "lvl5": {
-        "selector": ".theme-default-content h2",
-        "strip_chars": "#"
-      },
-      "text": ".theme-default-content p, .theme-default-content li, .theme-default-content td",
-      "lang": {
-        "selector": "/html/@lang",
-        "type": "xpath",
-        "global": true
-      }
-    },    
-    "flat": {
-      "lvl0": ".sidebar h4.version",
-      "lvl1": {
-        "selector": ".sidebar-heading.active+ul li a.active",
-        "global": true,
-        "default_value": "Documentation"
-      },
       "lvl2": {
-        "selector": ".sidebar-heading.active+ul li ul li a.active",
+        "selector": ".theme-default-content h2",
         "strip_chars": "#"
       },
       "lvl3": {
-        "selector": ".sidebar-heading.active+ul li ul li ul li a.active",
-        "strip_chars": "#"
-      },
-      "lvl4": {
-        "selector": ".theme-default-content h1",
-        "strip_chars": "#"
-      },
-      "lvl5": {
-        "selector": ".theme-default-content h2",
+        "selector": ".theme-default-content h3",
         "strip_chars": "#"
       },
       "text": ".theme-default-content p, .theme-default-content li, .theme-default-content td",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,4 +4,5 @@
   "files.exclude": {
     "node_modules/": true,
   },
+  "files.eol": "\n",
 }

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -8,11 +8,14 @@ import {resolveMultiSamplesPath} from "./lib/samples";
 import containers from "./lib/containers";
 import {replaceLinkPlugin} from "./markdown/replaceLink";
 import {linkCheckPlugin} from "./markdown/linkCheck";
+import {ESSidebarConfig} from "./configs/sidebar";
 
 require('dotenv').config({path: path.join(__dirname, '..', '..', '.algolia', '.env')})
 
+type ESThemeOptions = DefaultThemeOptions | {sidebar: ESSidebarConfig };
+
 // noinspection JSUnusedGlobalSymbols
-export default defineUserConfig<DefaultThemeOptions>({
+export default defineUserConfig<ESThemeOptions>({
     base: "/",
     dest: "public",
     title: "EventStoreDB Documentation",

--- a/docs/.vuepress/configs/sidebar.ts
+++ b/docs/.vuepress/configs/sidebar.ts
@@ -1,13 +1,13 @@
 import type { SidebarConfig, SidebarItem } from "@vuepress/theme-default";
 import { instance as ver } from "../lib/versioning";
 
-export type ESSidebarItem = SidebarItem & { header: string};
-export type ESSidebarConfig = SidebarConfig | Record<string, ESSidebarItem[]>
+export type GroupItem = { group: string, children: string[] };
+export type ESSidebarConfig = Record<string, GroupItem[]> | SidebarConfig | Record<string, SidebarItem[]>
 
 export const en: ESSidebarConfig = {
   "/clients/grpc/": [
     {
-      text: "gRPC clients",
+      group: "gRPC clients",
       children: [
         "/clients/grpc/README.md",
         "/clients/grpc/appending-events.md",
@@ -20,7 +20,7 @@ export const en: ESSidebarConfig = {
   ],
   "/cloud/": [
     {
-      text: "Event Store Cloud",
+      group: "Event Store Cloud",
       children: [
         "/cloud/intro/README.md",
         "/cloud/provision/README.md",

--- a/docs/.vuepress/markdown/replaceLink/index.ts
+++ b/docs/.vuepress/markdown/replaceLink/index.ts
@@ -19,7 +19,7 @@ interface resolveFunction {
 
 function checkFile(filepath: string): boolean {
     const p = filepath.split("#");
-    const basePath = path.resolve(__dirname, `../../..`);
+    const basePath = path.resolve(__dirname, '../../..');
     const filename = basePath + p[0];
     return fs.existsSync(filename);
 }

--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -19,3 +19,7 @@
 .site-name {
   display: none;
 }
+
+.sidebar .sidebar-items {
+  padding-top: 0;
+}

--- a/docs/.vuepress/theme/components/Version.vue
+++ b/docs/.vuepress/theme/components/Version.vue
@@ -14,24 +14,19 @@ export default {
     },
     version() {
         const path = this.$page.path;
-        const versions = __VERSIONS__.all.reduce(
-          (acc, val) =>
-            acc.concat(
-              val.versions?.map((v) => {
-                return {
-                  name: `${val.group} ${v.version}`,
-                  path: !!v.path ? `/${val.basePath}/${v.path}` : `/${val.basePath}`,
-                };
-              })
-            ),
-          []
-        );
 
-        const versionInfo = versions
-          .sort((a,b) => b.path.length - a.path.length)
+        const sidebar = this.$theme.sidebar;
+
+        var versionInfo = Object.keys(sidebar)
+          .map(key => { 
+            return { 
+              path: key, 
+              name: sidebar[key].map(v => [v.group, v.version].filter(Boolean).join(" "))[0] 
+            }; 
+          })
           .find(v => path.startsWith(v.path));
 
-        return versionInfo?.name;
+        return versionInfo?.name ?? "";
     }
   }
 }


### PR DESCRIPTION
- [x] - Aligned documentation section header rendering to be the same across all pages. Some pages (like database and TCP client) had a header at the top:

![obraz](https://user-images.githubusercontent.com/5562528/154050478-78a30569-5850-42a0-a30a-ec8c2885990a.png)

Some (like gRPC clients and Event Store Cloud) had it below:

![obraz](https://user-images.githubusercontent.com/5562528/154050562-0dd80ddb-9ac2-486d-95d1-792dace5eb97.png)

That was not looking great and made it hard to provide a unified Aglolia scrapping configuration.
- [x] - Fixed Algolia scrapping config