### PR TITLE
Fixed a typo in migration to gRPC docs

### DIFF
--- a/docs/clients/dotnet/21.2/migration-to-gRPC.md
+++ b/docs/clients/dotnet/21.2/migration-to-gRPC.md
@@ -407,7 +407,7 @@ The TCP Client has dedicated methods for reading events in the specific directio
 - `ReadStreamEventsForwardAsync`,
 - `ReadStreamEventsBackwardAsync`,
 - `ReadAllEventsForwardAsync`,
-- `ReadStreamEventsBackwardAsync`.
+- `ReadAllEventsBackwardAsync`.
 
 In the gRPC client, we unified those methods into methods with the direction parameter:
 - `ReadStreamAsync`,


### PR DESCRIPTION
Hi there! I found a typo while reading through the migration docs, and thought I'd submit a PR to fix it.

`ReadStreamEventsBackwardAsync` -> `ReadAllEventsBackwardAsync`