### PR TITLE
Fix typos and grammar in the TCP client subscriptions section

### DIFF
--- a/docs/clients/dotnet/20.10/subscriptions.md
+++ b/docs/clients/dotnet/20.10/subscriptions.md
@@ -18,7 +18,7 @@ You can set up a volatile subscription the same way as a catch-up subscription (
 
 Catch-up subscriptions serve the purpose of receiving events from a stream for a single subscriber. Subscribers for catch-up subscriptions get events in order and, therefore, are able to process events sequentially. There is nothing on the server that gets stored for such a subscriber.
 
-You can have multiple subscribers for the same stream and all those subscribers will get all the events from that stream. Subscriptions have no influence on each other and can run on their own pace.
+You can have multiple subscribers for the same stream and all those subscribers will get all the events from that stream. Subscriptions have no influence on each other and can run at their own pace.
 
 When creating a catch-up subscription on the client side, you can supply the starting position in the stream you are subscribing for. The subscriber will then get events from that position onwards. If the subscriber keeps the last known position in its own storage, it will be able to go down and resubscribe from the stored position in order to only get unprocessed events.
 
@@ -42,10 +42,10 @@ You can subscribe to any individual event stream in EventStoreDB. It could be a 
 
 Use the `IEventStoreConnection.SubscribeToStreamFrom` method to initiate the subscription. The connection must be open by the time you call this method.
 
-You need to specify the stream, which you want to subscribe to, the last known checkpoint, subscription settings and the event handling function. Optionally, you can a function, which then gets called when the subscription switches from processing historical events to real-time processing, and a function for handling subscription drops.
+You need to specify the stream which you want to subscribe to, the last known checkpoint, subscription settings, and the event handling function. Optionally, you can specify a function which gets called when the subscription switches from processing historical events to real-time processing, and another function for handling subscription drops.
 
 ::: tip Dropping subscription
-There are multiple reasons for a subscription to drop. The connection might close due to network issues, the subscription might get overloaded with events, or your event handler will throw an unhandled exception. It is usually a good idea to handle subscription drops and resubscribe when needed, to overcome transient issues. When a subscription drops, the application would keep working but will not process any events.
+There are multiple reasons for a subscription to drop. The connection might close due to network issues, the subscription might get overloaded with events, or your event handler might throw an unhandled exception. It is usually a good idea to handle subscription drops and resubscribe when needed, to overcome transient issues. When a subscription drops, the application would keep working but will not process any events.
 :::
 
 @[code{SubscribeToStream}](./sample-code/Subscriptions/CatchUp.cs)
@@ -54,7 +54,7 @@ In this code, we create an instance of `CatchUpSubscriptionSettings`. You can al
 
 ### Subscribing to `$all`
 
-Subscribing to the global event stream gives you a possibility to create read models from many different event streams. It is a powerful method to create, for example, reporting models with aggregated and denormalized data without using common database operations like `JOIN`. You must, however, carefully evaluate your subscription performance, as when you subscribe to `$all`, you'll get absolutely everything what gets appended to the EventStoreDB cluster. You might also need to filter out system events, by checking if event type starts with `$`. In normal applications, you won't need to process system events.
+Subscribing to the global event stream enables you to create read models from many different event streams. It is a powerful method to create, for example, reporting models with aggregated and denormalized data without using common database operations like `JOIN`. You must, however, carefully evaluate your subscription performance, as when you subscribe to `$all`, you'll get absolutely everything what gets appended to the EventStoreDB cluster. You might also need to filter out system events by checking if the event type starts with `$`. In normal applications, you won't need to process system events.
 
 As mentioned before, the checkpoint for `$all` is not a single numeric value, like it is for a single stream. You need to handle the checkpoint with two positions instead: commit and prepare position.
 
@@ -74,7 +74,7 @@ If you need to stop the subscription without closing the connection, you can use
 
 ## Persistent subscriptions
 
-In contrast to volatile and Catch-up types persistent subscriptions are not dropped when connection is closed. Moreover, this subscription type supports the "[competing consumers](https://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html)" messaging pattern and are useful when you need to distribute messages to many workers. EventStoreDB saves the subscription state server-side and allows for at-least-once delivery guarantees across multiple consumers on the same stream. It is possible to have many groups of consumers compete on the same stream, with each group getting an at-least-once guarantee.
+In contrast to volatile and catch-up types, persistent subscriptions are not dropped when the connection is closed. Moreover, this subscription type supports the "[competing consumers](https://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html)" messaging pattern and is useful when you need to distribute messages to many workers. EventStoreDB saves the subscription state server-side and allows for at-least-once delivery guarantees across multiple consumers on the same stream. It is possible to have many groups of consumers compete on the same stream, with each group getting an at-least-once guarantee.
 
 ::: tip
 The Administration UI includes a _Persistent Subscriptions_ section where a user can create, update, delete and view subscriptions and their statuses.
@@ -82,18 +82,18 @@ The Administration UI includes a _Persistent Subscriptions_ section where a user
 
 ### Concept
 
-Persistent subscriptions serve the same purpose as catch-up or volatile subscriptions, but in a different way. All subscriptions aim to deliver events in real-time to connected subscribers. But, unlike other subscription types, persistent subscriptions are maintained by the server. In a way, catch-up and persistent subscriptions are similar. Both have a last known position from where the subscription starts getting events. However, catch-up subscriptions must take care about keeping the last known position on the subscriber side and persistent subscriptions keep the position on the server.
+Persistent subscriptions serve the same purpose as catch-up or volatile subscriptions, but in a different way. All subscriptions aim to deliver events in real-time to connected subscribers. But, unlike other subscription types, persistent subscriptions are maintained by the server. In a way, catch-up and persistent subscriptions are similar. Both have a last known position from where the subscription starts getting events. However, catch-up subscriptions must take care about keeping the last known position on the subscriber side while persistent subscriptions keep the position on the server.
 
 Since it is the server who decides from where the subscription should start receiving events and knows where events are delivered, subscribers that use a persistent subscription can be load-balanced and process events in parallel. In contrast, catch-up subscriptions, which are client-driven, always receive and process events sequentially and can only be load-balanced on the client side. Therefore, persistent subscriptions allow using the competing consumers pattern that is common in the world of message brokers.
 
-In order for the server to load-balance subscribers, it uses the concept of consumer groups. All clients that belong to a single consumer group will get a portion of events and that's how load balancing works inside a group. It is possible to create multiple consumer groups for the same stream, and they will be completely independent of each other, receiving and processing events in their own pace and having their own last known position handled by the server.
+In order for the server to load-balance subscribers, it uses the concept of consumer groups. All clients that belong to a single consumer group will get a portion of events and that's how load balancing works inside a group. It is possible to create multiple consumer groups for the same stream, and they will be completely independent of each other, receiving and processing events at their own pace and having their own last known position handled by the server.
 
 ::: card
 ![Consumer groups](./images/consumer-groups.jpg)
 :::
 
 ::: note
-Just as in the world of message brokers, processing events in a group of consumers running in parallel processes will most likely get evens out of order within a certain window. For example, if a consumer group has ten consumers, ten messages will be distributed among the available consumers, based on the [strategy](#consumer-strategies) of the group. Even though some strategies make an attempt to consistently deliver ordered events to a single consumer, it's done on the best effort basis and there is no guarantee of events coming in order with any strategy.
+Just as in the world of message brokers, processing events in a group of consumers running in parallel processes will most likely get events out of order within a certain window. For example, if a consumer group has ten consumers, ten messages will be distributed among the available consumers, based on the [strategy](#consumer-strategies) of the group. Even though some strategies make an attempt to consistently deliver ordered events to a single consumer, it's done on a best effort basis and there is no guarantee of events coming in order with any strategy.
 :::
 
 ### Creating a subscription group
@@ -119,16 +119,16 @@ var result = await connection.CreatePersistentSubscriptionAsync(
 );
 ```
 
-| Parameter                                 | Description                                          |
-|:------------------------------------------|:-----------------------------------------------------|
-| `string stream`                           | The stream to the persistent subscription is on.     |
-| `string groupName`                        | The name of the subscription group to create.        |
-| `PersistentSubscriptionSettings settings` | The settings to use when creating this subscription. |
-| `UserCredentials credentials`             | The user credentials to use for this operation.      |
+| Parameter                                 | Description                                                     |
+|:------------------------------------------|:----------------------------------------------------------------|
+| `string stream`                           | The name of the stream which the persistent subscription is on. |
+| `string groupName`                        | The name of the subscription group to create.                   |
+| `PersistentSubscriptionSettings settings` | The settings to use when creating this subscription.            |
+| `UserCredentials credentials`             | The user credentials to use for this operation.                 |
 
 ### Connecting to an existing group
 
-Once you have created a subscription group, clients can connect to that subscription group. A subscription in your application should only have the connection in your code, you should assume that the subscription was created via the client API, the restful API, or manually in the UI.
+Once you have created a subscription group, clients can connect to that subscription group. A subscription in your application should only have the connection in your code, and you should assume that the subscription was created via the client API, the restful API, or manually in the UI.
 
 The most important parameter to pass when connecting is the buffer size. This parameter represents how many outstanding messages the server should allow this client. If this number is too small, your subscription will spend much of its time idle as it waits for an acknowledgment to come back from the client. If it's too big, you waste resources and can start causing time out messages depending on the speed of your processing.
 
@@ -147,21 +147,21 @@ var subscription = await connection.ConnectToPersistentSubscriptionAsync(
 );
 ```
 
-| Parameter                     | Description                                                                |
-|:------------------------------|:---------------------------------------------------------------------------|
-| `string stream`               | The stream to the persistent subscription is on.                           |
-| `string groupName`            | The name of the subscription group to connect to.                          |
-| `Action eventAppeared`        | The action to call when an event arrives over the subscription.            |
-| `Action subscriptionDropped`  | The action to call if the subscription is dropped.                         |
-| `UserCredentials credentials` | The user credentials to use for this operation.                            |
-| `int bufferSize`              | The number of in-flight messages this client is allowed.                   |
-| `bool autoAck`                | Whether to automatically acknowledge messages after eventAppeared returns. |
+| Parameter                     | Description                                                                  |
+|:------------------------------|:-----------------------------------------------------------------------------|
+| `string stream`               | The name of the stream which the persistent subscription is on.              |
+| `string groupName`            | The name of the subscription group to connect to.                            |
+| `Action eventAppeared`        | The action to call when an event arrives over the subscription.              |
+| `Action subscriptionDropped`  | The action to call if the subscription is dropped.                           |
+| `UserCredentials credentials` | The user credentials to use for this operation.                              |
+| `int bufferSize`              | The number of in-flight messages this client is allowed.                     |
+| `bool autoAck`                | Whether to automatically acknowledge messages after `eventAppeared` returns. |
 
 ### Acknowledging events
 
-Clients must acknowledge (or not acknowledge) messages in the competing consumer model. If you enable auto-ack the subscription will automatically acknowledge messages once your handler completes them. If you throw an exception, it will shut down your subscription with a message and the uncaught exception.
+Clients must acknowledge (or not acknowledge) messages in the competing consumer model. If you enable auto-ack, the subscription will automatically acknowledge messages once your handler completes them. If you throw an exception, it will shut down your subscription with a message and the uncaught exception.
 
-You can choose to not auto-ack messages. This can be useful when you have multi-threaded processing of messages in your subscriber and need to pass control to something else. There are methods on the subscription object that you can call `Acknowledge,` and `NotAcknowledge` both take a `ResolvedEvent` (the one you processed) both also have overloads for passing and `IEnumerable<ResolvedEvent>`.
+You can choose to not auto-ack messages. This can be useful when you have multi-threaded processing of messages in your subscriber and need to pass control to something else. There are methods on the subscription object that you can call: `Acknowledge` and `NotAcknowledge`. Both take a `ResolvedEvent` (the one you processed) and both also have overloads for passing an `IEnumerable<ResolvedEvent>`.
 
 ### Consumer strategies
 
@@ -183,7 +183,7 @@ This option can be seen as a fall-back scenario for high availability, when a si
 
 For use with an indexing projection such as the system `$by_category` projection.
 
-EventStoreDB inspects event for its source stream id, hashing the id to one of 1024 buckets assigned to individual clients. When a client disconnects its buckets are assigned to other clients. When a client connects, it is assigned some of the existing buckets. This naively attempts to maintain a balanced workload.
+EventStoreDB inspects the event for its source stream id, hashing the id to one of 1024 buckets assigned to individual clients. When a client disconnects its buckets are assigned to other clients. When a client connects, it is assigned some of the existing buckets. This naively attempts to maintain a balanced workload.
 
 The main aim of this strategy is to decrease the likelihood of concurrency and ordering issues while maintaining load balancing. _This is not a guarantee_, and you should handle the usual ordering and concurrency issues.
 
@@ -201,7 +201,7 @@ public Task ReplayParkedMessages(
 
 ### Updating a subscription group
 
-You can edit the settings of an existing subscription group while it is running, you don't need to delete and recreate it to change settings. When you update the subscription group, it resets itself internally dropping the connections and having them reconnect. You must have admin permissions to update a persistent subscription group.
+You can edit the settings of an existing subscription group while it is running instead of deleting the subscription group and recreating it to change its settings. When you update a subscription group, it resets itself internally, dropping the connections and having them reconnect. You must have admin permissions to update a persistent subscription group.
 
 ```csharp
 var settings = PersistentSubscriptionSettings
@@ -218,12 +218,12 @@ var result = await connection.UpdatePersistentSubscriptionAsync(
 If you change settings such as `startFromBeginning`, this doesn't reset the group's checkpoint. If you want to change the current position in an update, you must delete and recreate the subscription group.
 :::
 
-| Parameter                                 | Description                                          |
-|:------------------------------------------|:-----------------------------------------------------|
-| `string stream`                           | The stream to the persistent subscription is on.     |
-| `string groupName`                        | The name of the subscription group to update.        |
-| `PersistentSubscriptionSettings settings` | The settings to use when updating this subscription. |
-| `UserCredentials credentials`             | The user credentials to use for this operation.      |
+| Parameter                                 | Description                                                     |
+|:------------------------------------------|:----------------------------------------------------------------|
+| `string stream`                           | The name of the stream which the persistent subscription is on. |
+| `string groupName`                        | The name of the subscription group to update.                   |
+| `PersistentSubscriptionSettings settings` | The settings to use when updating this subscription.            |
+| `UserCredentials credentials`             | The user credentials to use for this operation.                 |
 
 ### Persistent subscription settings
 
@@ -238,28 +238,28 @@ var settings = PersistentSubscriptionSettings
 
 The following table shows the options you can set on a persistent subscription.
 
-| Member                                   | Description                                                                                                       |
-|:-----------------------------------------|:------------------------------------------------------------------------------------------------------------------|
-| `ResolveLinkTos`                         | Tells the subscription to resolve link events.                                                                    |
-| `DoNotResolveLinkTos`                    | Tells the subscription to not resolve link events.                                                                |
-| `PreferRoundRobin`                       | If possible preference a round robin between the connections with messages (if not possible uses next available). |
-| `PreferDispatchToSingle`                 | If possible preference dispatching to a single connection (if not possible will use next available).              |
-| `StartFromBeginning`                     | Start the subscription from the first event in the stream.                                                        |
-| `StartFrom(int position)`                | Start the subscription from the position-th event in the stream.                                                  |
-| `StartFromCurrent`                       | Start the subscription from the current position.                                                                 |
-| `WithMessageTimeoutOf(TimeSpan timeout)` | Sets the timeout for a client before retrying the message.                                                        |
-| `CheckPointAfter(TimeSpan time)`         | The amount of time the system should try to checkpoint after.                                                     |
-| `MinimumCheckPointCountOf(int count)`    | The minimum number of messages to write a checkpoint for.                                                         |
-| `MaximumCheckPointCountOf(int count)`    | The maximum number of messages not checkpointed before forcing a checkpoint.                                      |
-| `WithMaxRetriesOf(int count)`            | Sets the number of times to retry a message should before considering it a bad message.                           |
-| `WithLiveBufferSizeOf(int count)`        | The size of the live buffer (in memory) before resorting to paging.                                               |
-| `WithReadBatchOf(int count)`             | The size of the read batch when in paging mode.                                                                   |
-| `WithBufferSizeOf(int count)`            | The number of messages to buffer when in paging mode.                                                             |
-| `WithExtraStatistics`                    | Tells the backend to measure timings on the clients so statistics contain histograms of them.                     |
+| Member                                   | Description                                                                                                          |
+|:-----------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
+| `ResolveLinkTos`                         | Tells the subscription to resolve link events.                                                                       |
+| `DoNotResolveLinkTos`                    | Tells the subscription to not resolve link events.                                                                   |
+| `PreferRoundRobin`                       | If possible, prefers a round robin between the connections with messages (Will use next available if not possible).  |
+| `PreferDispatchToSingle`                 | If possible, prefers dispatching to a single connection (Will use next available if not possible).                   |
+| `StartFromBeginning`                     | Starts the subscription from the first event in the stream.                                                          |
+| `StartFrom(int position)`                | Starts the subscription from the position-th event in the stream.                                                    |
+| `StartFromCurrent`                       | Starts the subscription from the current position.                                                                   |
+| `WithMessageTimeoutOf(TimeSpan timeout)` | Sets the timeout for a client before retrying the message.                                                           |
+| `CheckPointAfter(TimeSpan time)`         | The amount of time the system should try to checkpoint after.                                                        |
+| `MinimumCheckPointCountOf(int count)`    | The minimum number of messages to write a checkpoint for.                                                            |
+| `MaximumCheckPointCountOf(int count)`    | The maximum number of messages not checkpointed before forcing a checkpoint.                                         |
+| `WithMaxRetriesOf(int count)`            | Sets the number of times to retry a message should before considering it a bad message.                              |
+| `WithLiveBufferSizeOf(int count)`        | The size of the live buffer (in memory) before resorting to paging.                                                  |
+| `WithReadBatchOf(int count)`             | The size of the read batch when in paging mode.                                                                      |
+| `WithBufferSizeOf(int count)`            | The number of messages to buffer when in paging mode.                                                                |
+| `WithExtraStatistics`                    | Tells the backend to measure timings on the clients so statistics contain histograms of them.                        |
 
 ### Deleting a subscription group
 
-Remove a subscription group with the delete operation. Like the creation of groups, you rarely do this in your runtime code and is undertaken by an administrator running a script.
+The delete operation can be used to remove a subscription group. Like the creation of groups, you rarely do this in your runtime code and is undertaken by an administrator running a script.
 
 ```csharp
 var result = await connection.DeletePersistentSubscriptionAsync(
@@ -267,11 +267,11 @@ var result = await connection.DeletePersistentSubscriptionAsync(
 );
 ```
 
-| Parameter                     | Description                                      |
-|:------------------------------|:-------------------------------------------------|
-| `string stream`               | The stream to the persistent subscription is on. |
-| `string groupName`            | The name of the subscription group to update.    |
-| `UserCredentials credentials` | The user credentials to use for this operation.  |
+| Parameter                     | Description                                                     |
+|:------------------------------|:----------------------------------------------------------------|
+| `string stream`               | The name of the stream which the persistent subscription is on. |
+| `string groupName`            | The name of the subscription group to update.                   |
+| `UserCredentials credentials` | The user credentials to use for this operation.                 |
 
 ### Monitoring persistent subscriptions
 
@@ -279,7 +279,7 @@ The client API includes helper methods that wrap the HTTP API to allow you to mo
 
 #### Create the manager instance
 
-Before accessing any of the methods described below, you need to create an instance of the `PersistentSubscriptionsManager` class. It needs a logger instance and one of the variations of the `EndPoint` abstract class. You would normally use either the `IpEndPoint` or `DnsEndPoint`. Since all HTTP calls would be redirected to the cluster leader, you can use an IP address of any cluster node. When using the `DnsEndPoint`, you can specify the DNS name of the cluster.
+Before accessing any of the methods described below, you need to create an instance of the `PersistentSubscriptionsManager` class. It needs a logger instance and one of the variations of the `EndPoint` abstract class. You would normally use either the `IpEndPoint` or `DnsEndPoint`. Since all HTTP calls would be redirected to the cluster leader, you can use the IP address of any cluster node. When using the `DnsEndPoint`, you can specify the DNS name of the cluster.
 
 For example:
 

--- a/docs/clients/dotnet/21.2/subscriptions.md
+++ b/docs/clients/dotnet/21.2/subscriptions.md
@@ -18,7 +18,7 @@ You can set up a volatile subscription the same way as a catch-up subscription (
 
 Catch-up subscriptions serve the purpose of receiving events from a stream for a single subscriber. Subscribers for catch-up subscriptions get events in order and, therefore, are able to process events sequentially. There is nothing on the server that gets stored for such a subscriber.
 
-You can have multiple subscribers for the same stream and all those subscribers will get all the events from that stream. Subscriptions have no influence on each other and can run on their own pace.
+You can have multiple subscribers for the same stream and all those subscribers will get all the events from that stream. Subscriptions have no influence on each other and can run at their own pace.
 
 When creating a catch-up subscription on the client side, you can supply the starting position in the stream you are subscribing for. The subscriber will then get events from that position onwards. If the subscriber keeps the last known position in its own storage, it will be able to go down and resubscribe from the stored position in order to only get unprocessed events.
 
@@ -42,10 +42,10 @@ You can subscribe to any individual event stream in EventStoreDB. It could be a 
 
 Use the `IEventStoreConnection.SubscribeToStreamFrom` method to initiate the subscription. The connection must be open by the time you call this method.
 
-You need to specify the stream, which you want to subscribe to, the last known checkpoint, subscription settings and the event handling function. Optionally, you can a function, which then gets called when the subscription switches from processing historical events to real-time processing, and a function for handling subscription drops.
+You need to specify the stream which you want to subscribe to, the last known checkpoint, subscription settings, and the event handling function. Optionally, you can specify a function which gets called when the subscription switches from processing historical events to real-time processing, and another function for handling subscription drops.
 
 ::: tip Dropping subscription
-There are multiple reasons for a subscription to drop. The connection might close due to network issues, the subscription might get overloaded with events, or your event handler will throw an unhandled exception. It is usually a good idea to handle subscription drops and resubscribe when needed, to overcome transient issues. When a subscription drops, the application would keep working but will not process any events.
+There are multiple reasons for a subscription to drop. The connection might close due to network issues, the subscription might get overloaded with events, or your event handler might throw an unhandled exception. It is usually a good idea to handle subscription drops and resubscribe when needed, to overcome transient issues. When a subscription drops, the application would keep working but will not process any events.
 :::
 
 @[code{SubscribeToStream}](./sample-code/Subscriptions/CatchUp.cs)
@@ -54,7 +54,7 @@ In this code, we create an instance of `CatchUpSubscriptionSettings`. You can al
 
 ### Subscribing to `$all`
 
-Subscribing to the global event stream gives you a possibility to create read models from many different event streams. It is a powerful method to create, for example, reporting models with aggregated and denormalized data without using common database operations like `JOIN`. You must, however, carefully evaluate your subscription performance, as when you subscribe to `$all`, you'll get absolutely everything what gets appended to the EventStoreDB cluster. You might also need to filter out system events, by checking if event type starts with `$`. In normal applications, you won't need to process system events.
+Subscribing to the global event stream enables you to create read models from many different event streams. It is a powerful method to create, for example, reporting models with aggregated and denormalized data without using common database operations like `JOIN`. You must, however, carefully evaluate your subscription performance, as when you subscribe to `$all`, you'll get absolutely everything what gets appended to the EventStoreDB cluster. You might also need to filter out system events by checking if the event type starts with `$`. In normal applications, you won't need to process system events.
 
 As mentioned before, the checkpoint for `$all` is not a single numeric value, like it is for a single stream. You need to handle the checkpoint with two positions instead: commit and prepare position.
 
@@ -74,7 +74,7 @@ If you need to stop the subscription without closing the connection, you can use
 
 ## Persistent subscriptions
 
-In contrast to volatile and Catch-up types persistent subscriptions are not dropped when connection is closed. Moreover, this subscription type supports the "[competing consumers](https://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html)" messaging pattern and are useful when you need to distribute messages to many workers. EventStoreDB saves the subscription state server-side and allows for at-least-once delivery guarantees across multiple consumers on the same stream. It is possible to have many groups of consumers compete on the same stream, with each group getting an at-least-once guarantee.
+In contrast to volatile and catch-up types, persistent subscriptions are not dropped when the connection is closed. Moreover, this subscription type supports the "[competing consumers](https://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html)" messaging pattern and is useful when you need to distribute messages to many workers. EventStoreDB saves the subscription state server-side and allows for at-least-once delivery guarantees across multiple consumers on the same stream. It is possible to have many groups of consumers compete on the same stream, with each group getting an at-least-once guarantee.
 
 ::: tip
 The Administration UI includes a _Persistent Subscriptions_ section where a user can create, update, delete and view subscriptions and their statuses.
@@ -82,18 +82,18 @@ The Administration UI includes a _Persistent Subscriptions_ section where a user
 
 ### Concept
 
-Persistent subscriptions serve the same purpose as catch-up or volatile subscriptions, but in a different way. All subscriptions aim to deliver events in real-time to connected subscribers. But, unlike other subscription types, persistent subscriptions are maintained by the server. In a way, catch-up and persistent subscriptions are similar. Both have a last known position from where the subscription starts getting events. However, catch-up subscriptions must take care about keeping the last known position on the subscriber side and persistent subscriptions keep the position on the server.
+Persistent subscriptions serve the same purpose as catch-up or volatile subscriptions, but in a different way. All subscriptions aim to deliver events in real-time to connected subscribers. But, unlike other subscription types, persistent subscriptions are maintained by the server. In a way, catch-up and persistent subscriptions are similar. Both have a last known position from where the subscription starts getting events. However, catch-up subscriptions must take care about keeping the last known position on the subscriber side while persistent subscriptions keep the position on the server.
 
 Since it is the server who decides from where the subscription should start receiving events and knows where events are delivered, subscribers that use a persistent subscription can be load-balanced and process events in parallel. In contrast, catch-up subscriptions, which are client-driven, always receive and process events sequentially and can only be load-balanced on the client side. Therefore, persistent subscriptions allow using the competing consumers pattern that is common in the world of message brokers.
 
-In order for the server to load-balance subscribers, it uses the concept of consumer groups. All clients that belong to a single consumer group will get a portion of events and that's how load balancing works inside a group. It is possible to create multiple consumer groups for the same stream, and they will be completely independent of each other, receiving and processing events in their own pace and having their own last known position handled by the server.
+In order for the server to load-balance subscribers, it uses the concept of consumer groups. All clients that belong to a single consumer group will get a portion of events and that's how load balancing works inside a group. It is possible to create multiple consumer groups for the same stream, and they will be completely independent of each other, receiving and processing events at their own pace and having their own last known position handled by the server.
 
 ::: card
 ![Consumer groups](./images/consumer-groups.jpg)
 :::
 
 ::: note
-Just as in the world of message brokers, processing events in a group of consumers running in parallel processes will most likely get evens out of order within a certain window. For example, if a consumer group has ten consumers, ten messages will be distributed among the available consumers, based on the [strategy](#consumer-strategies) of the group. Even though some strategies make an attempt to consistently deliver ordered events to a single consumer, it's done on the best effort basis and there is no guarantee of events coming in order with any strategy.
+Just as in the world of message brokers, processing events in a group of consumers running in parallel processes will most likely get events out of order within a certain window. For example, if a consumer group has ten consumers, ten messages will be distributed among the available consumers, based on the [strategy](#consumer-strategies) of the group. Even though some strategies make an attempt to consistently deliver ordered events to a single consumer, it's done on a best effort basis and there is no guarantee of events coming in order with any strategy.
 :::
 
 ### Creating a subscription group
@@ -119,16 +119,16 @@ var result = await connection.CreatePersistentSubscriptionAsync(
 );
 ```
 
-| Parameter                                 | Description                                          |
-|:------------------------------------------|:-----------------------------------------------------|
-| `string stream`                           | The stream to the persistent subscription is on.     |
-| `string groupName`                        | The name of the subscription group to create.        |
-| `PersistentSubscriptionSettings settings` | The settings to use when creating this subscription. |
-| `UserCredentials credentials`             | The user credentials to use for this operation.      |
+| Parameter                                 | Description                                                     |
+|:------------------------------------------|:----------------------------------------------------------------|
+| `string stream`                           | The name of the stream which the persistent subscription is on. |
+| `string groupName`                        | The name of the subscription group to create.                   |
+| `PersistentSubscriptionSettings settings` | The settings to use when creating this subscription.            |
+| `UserCredentials credentials`             | The user credentials to use for this operation.                 |
 
 ### Connecting to an existing group
 
-Once you have created a subscription group, clients can connect to that subscription group. A subscription in your application should only have the connection in your code, you should assume that the subscription was created via the client API, the restful API, or manually in the UI.
+Once you have created a subscription group, clients can connect to that subscription group. A subscription in your application should only have the connection in your code, and you should assume that the subscription was created via the client API, the restful API, or manually in the UI.
 
 The most important parameter to pass when connecting is the buffer size. This parameter represents how many outstanding messages the server should allow this client. If this number is too small, your subscription will spend much of its time idle as it waits for an acknowledgment to come back from the client. If it's too big, you waste resources and can start causing time out messages depending on the speed of your processing.
 
@@ -147,21 +147,21 @@ var subscription = await connection.ConnectToPersistentSubscriptionAsync(
 );
 ```
 
-| Parameter                     | Description                                                                |
-|:------------------------------|:---------------------------------------------------------------------------|
-| `string stream`               | The stream to the persistent subscription is on.                           |
-| `string groupName`            | The name of the subscription group to connect to.                          |
-| `Action eventAppeared`        | The action to call when an event arrives over the subscription.            |
-| `Action subscriptionDropped`  | The action to call if the subscription is dropped.                         |
-| `UserCredentials credentials` | The user credentials to use for this operation.                            |
-| `int bufferSize`              | The number of in-flight messages this client is allowed.                   |
-| `bool autoAck`                | Whether to automatically acknowledge messages after eventAppeared returns. |
+| Parameter                     | Description                                                                  |
+|:------------------------------|:-----------------------------------------------------------------------------|
+| `string stream`               | The name of the stream which the persistent subscription is on.              |
+| `string groupName`            | The name of the subscription group to connect to.                            |
+| `Action eventAppeared`        | The action to call when an event arrives over the subscription.              |
+| `Action subscriptionDropped`  | The action to call if the subscription is dropped.                           |
+| `UserCredentials credentials` | The user credentials to use for this operation.                              |
+| `int bufferSize`              | The number of in-flight messages this client is allowed.                     |
+| `bool autoAck`                | Whether to automatically acknowledge messages after `eventAppeared` returns. |
 
 ### Acknowledging events
 
-Clients must acknowledge (or not acknowledge) messages in the competing consumer model. If you enable auto-ack the subscription will automatically acknowledge messages once your handler completes them. If you throw an exception, it will shut down your subscription with a message and the uncaught exception.
+Clients must acknowledge (or not acknowledge) messages in the competing consumer model. If you enable auto-ack, the subscription will automatically acknowledge messages once your handler completes them. If you throw an exception, it will shut down your subscription with a message and the uncaught exception.
 
-You can choose to not auto-ack messages. This can be useful when you have multi-threaded processing of messages in your subscriber and need to pass control to something else. There are methods on the subscription object that you can call `Acknowledge,` and `NotAcknowledge` both take a `ResolvedEvent` (the one you processed) both also have overloads for passing and `IEnumerable<ResolvedEvent>`.
+You can choose to not auto-ack messages. This can be useful when you have multi-threaded processing of messages in your subscriber and need to pass control to something else. There are methods on the subscription object that you can call: `Acknowledge` and `NotAcknowledge`. Both take a `ResolvedEvent` (the one you processed) and both also have overloads for passing an `IEnumerable<ResolvedEvent>`.
 
 ### Consumer strategies
 
@@ -183,7 +183,7 @@ This option can be seen as a fall-back scenario for high availability, when a si
 
 For use with an indexing projection such as the system `$by_category` projection.
 
-EventStoreDB inspects event for its source stream id, hashing the id to one of 1024 buckets assigned to individual clients. When a client disconnects its buckets are assigned to other clients. When a client connects, it is assigned some of the existing buckets. This naively attempts to maintain a balanced workload.
+EventStoreDB inspects the event for its source stream id, hashing the id to one of 1024 buckets assigned to individual clients. When a client disconnects its buckets are assigned to other clients. When a client connects, it is assigned some of the existing buckets. This naively attempts to maintain a balanced workload.
 
 The main aim of this strategy is to decrease the likelihood of concurrency and ordering issues while maintaining load balancing. _This is not a guarantee_, and you should handle the usual ordering and concurrency issues.
 
@@ -201,7 +201,7 @@ public Task ReplayParkedMessages(
 
 ### Updating a subscription group
 
-You can edit the settings of an existing subscription group while it is running, you don't need to delete and recreate it to change settings. When you update the subscription group, it resets itself internally dropping the connections and having them reconnect. You must have admin permissions to update a persistent subscription group.
+You can edit the settings of an existing subscription group while it is running instead of deleting the subscription group and recreating it to change its settings. When you update a subscription group, it resets itself internally, dropping the connections and having them reconnect. You must have admin permissions to update a persistent subscription group.
 
 ```csharp
 var settings = PersistentSubscriptionSettings
@@ -218,12 +218,12 @@ var result = await connection.UpdatePersistentSubscriptionAsync(
 If you change settings such as `startFromBeginning`, this doesn't reset the group's checkpoint. If you want to change the current position in an update, you must delete and recreate the subscription group.
 :::
 
-| Parameter                                 | Description                                          |
-|:------------------------------------------|:-----------------------------------------------------|
-| `string stream`                           | The stream to the persistent subscription is on.     |
-| `string groupName`                        | The name of the subscription group to update.        |
-| `PersistentSubscriptionSettings settings` | The settings to use when updating this subscription. |
-| `UserCredentials credentials`             | The user credentials to use for this operation.      |
+| Parameter                                 | Description                                                     |
+|:------------------------------------------|:----------------------------------------------------------------|
+| `string stream`                           | The name of the stream which the persistent subscription is on. |
+| `string groupName`                        | The name of the subscription group to update.                   |
+| `PersistentSubscriptionSettings settings` | The settings to use when updating this subscription.            |
+| `UserCredentials credentials`             | The user credentials to use for this operation.                 |
 
 ### Persistent subscription settings
 
@@ -238,28 +238,28 @@ var settings = PersistentSubscriptionSettings
 
 The following table shows the options you can set on a persistent subscription.
 
-| Member                                   | Description                                                                                                       |
-|:-----------------------------------------|:------------------------------------------------------------------------------------------------------------------|
-| `ResolveLinkTos`                         | Tells the subscription to resolve link events.                                                                    |
-| `DoNotResolveLinkTos`                    | Tells the subscription to not resolve link events.                                                                |
-| `PreferRoundRobin`                       | If possible preference a round robin between the connections with messages (if not possible uses next available). |
-| `PreferDispatchToSingle`                 | If possible preference dispatching to a single connection (if not possible will use next available).              |
-| `StartFromBeginning`                     | Start the subscription from the first event in the stream.                                                        |
-| `StartFrom(int position)`                | Start the subscription from the position-th event in the stream.                                                  |
-| `StartFromCurrent`                       | Start the subscription from the current position.                                                                 |
-| `WithMessageTimeoutOf(TimeSpan timeout)` | Sets the timeout for a client before retrying the message.                                                        |
-| `CheckPointAfter(TimeSpan time)`         | The amount of time the system should try to checkpoint after.                                                     |
-| `MinimumCheckPointCountOf(int count)`    | The minimum number of messages to write a checkpoint for.                                                         |
-| `MaximumCheckPointCountOf(int count)`    | The maximum number of messages not checkpointed before forcing a checkpoint.                                      |
-| `WithMaxRetriesOf(int count)`            | Sets the number of times to retry a message should before considering it a bad message.                           |
-| `WithLiveBufferSizeOf(int count)`        | The size of the live buffer (in memory) before resorting to paging.                                               |
-| `WithReadBatchOf(int count)`             | The size of the read batch when in paging mode.                                                                   |
-| `WithBufferSizeOf(int count)`            | The number of messages to buffer when in paging mode.                                                             |
-| `WithExtraStatistics`                    | Tells the backend to measure timings on the clients so statistics contain histograms of them.                     |
+| Member                                   | Description                                                                                                          |
+|:-----------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
+| `ResolveLinkTos`                         | Tells the subscription to resolve link events.                                                                       |
+| `DoNotResolveLinkTos`                    | Tells the subscription to not resolve link events.                                                                   |
+| `PreferRoundRobin`                       | If possible, prefers a round robin between the connections with messages (Will use next available if not possible).  |
+| `PreferDispatchToSingle`                 | If possible, prefers dispatching to a single connection (Will use next available if not possible).                   |
+| `StartFromBeginning`                     | Starts the subscription from the first event in the stream.                                                          |
+| `StartFrom(int position)`                | Starts the subscription from the position-th event in the stream.                                                    |
+| `StartFromCurrent`                       | Starts the subscription from the current position.                                                                   |
+| `WithMessageTimeoutOf(TimeSpan timeout)` | Sets the timeout for a client before retrying the message.                                                           |
+| `CheckPointAfter(TimeSpan time)`         | The amount of time the system should try to checkpoint after.                                                        |
+| `MinimumCheckPointCountOf(int count)`    | The minimum number of messages to write a checkpoint for.                                                            |
+| `MaximumCheckPointCountOf(int count)`    | The maximum number of messages not checkpointed before forcing a checkpoint.                                         |
+| `WithMaxRetriesOf(int count)`            | Sets the number of times to retry a message should before considering it a bad message.                              |
+| `WithLiveBufferSizeOf(int count)`        | The size of the live buffer (in memory) before resorting to paging.                                                  |
+| `WithReadBatchOf(int count)`             | The size of the read batch when in paging mode.                                                                      |
+| `WithBufferSizeOf(int count)`            | The number of messages to buffer when in paging mode.                                                                |
+| `WithExtraStatistics`                    | Tells the backend to measure timings on the clients so statistics contain histograms of them.                        |
 
 ### Deleting a subscription group
 
-Remove a subscription group with the delete operation. Like the creation of groups, you rarely do this in your runtime code and is undertaken by an administrator running a script.
+The delete operation can be used to remove a subscription group. Like the creation of groups, you rarely do this in your runtime code and is undertaken by an administrator running a script.
 
 ```csharp
 var result = await connection.DeletePersistentSubscriptionAsync(
@@ -267,11 +267,11 @@ var result = await connection.DeletePersistentSubscriptionAsync(
 );
 ```
 
-| Parameter                     | Description                                      |
-|:------------------------------|:-------------------------------------------------|
-| `string stream`               | The stream to the persistent subscription is on. |
-| `string groupName`            | The name of the subscription group to update.    |
-| `UserCredentials credentials` | The user credentials to use for this operation.  |
+| Parameter                     | Description                                                     |
+|:------------------------------|:----------------------------------------------------------------|
+| `string stream`               | The name of the stream which the persistent subscription is on. |
+| `string groupName`            | The name of the subscription group to update.                   |
+| `UserCredentials credentials` | The user credentials to use for this operation.                 |
 
 ### Monitoring persistent subscriptions
 
@@ -279,7 +279,7 @@ The client API includes helper methods that wrap the HTTP API to allow you to mo
 
 #### Create the manager instance
 
-Before accessing any of the methods described below, you need to create an instance of the `PersistentSubscriptionsManager` class. It needs a logger instance and one of the variations of the `EndPoint` abstract class. You would normally use either the `IpEndPoint` or `DnsEndPoint`. Since all HTTP calls would be redirected to the cluster leader, you can use an IP address of any cluster node. When using the `DnsEndPoint`, you can specify the DNS name of the cluster.
+Before accessing any of the methods described below, you need to create an instance of the `PersistentSubscriptionsManager` class. It needs a logger instance and one of the variations of the `EndPoint` abstract class. You would normally use either the `IpEndPoint` or `DnsEndPoint`. Since all HTTP calls would be redirected to the cluster leader, you can use the IP address of any cluster node. When using the `DnsEndPoint`, you can specify the DNS name of the cluster.
 
 For example:
 

--- a/docs/clients/dotnet/5.0/subscriptions.md
+++ b/docs/clients/dotnet/5.0/subscriptions.md
@@ -18,7 +18,7 @@ You can set up a volatile subscription the same way as a catch-up subscription (
 
 Catch-up subscriptions serve the purpose of receiving events from a stream for a single subscriber. Subscribers for catch-up subscriptions get events in order and, therefore, are able to process events sequentially. There is nothing on the server that gets stored for such a subscriber.
 
-You can have multiple subscribers for the same stream and all those subscribers will get all the events from that stream. Subscriptions have no influence on each other and can run on their own pace.
+You can have multiple subscribers for the same stream and all those subscribers will get all the events from that stream. Subscriptions have no influence on each other and can run at their own pace.
 
 When creating a catch-up subscription on the client side, you can supply the starting position in the stream you are subscribing for. The subscriber will then get events from that position onwards. If the subscriber keeps the last known position in its own storage, it will be able to go down and resubscribe from the stored position in order to only get unprocessed events.
 
@@ -42,10 +42,10 @@ You can subscribe to any individual event stream in EventStoreDB. It could be a 
 
 Use the `IEventStoreConnection.SubscribeToStreamFrom` method to initiate the subscription. The connection must be open by the time you call this method.
 
-You need to specify the stream, which you want to subscribe to, the last known checkpoint, subscription settings and the event handling function. Optionally, you can a function, which then gets called when the subscription switches from processing historical events to real-time processing, and a function for handling subscription drops.
+You need to specify the stream which you want to subscribe to, the last known checkpoint, subscription settings, and the event handling function. Optionally, you can specify a function which gets called when the subscription switches from processing historical events to real-time processing, and another function for handling subscription drops.
 
 ::: tip Dropping subscription
-There are multiple reasons for a subscription to drop. The connection might close due to network issues, the subscription might get overloaded with events, or your event handler will throw an unhandled exception. It is usually a good idea to handle subscription drops and resubscribe when needed, to overcome transient issues. When a subscription drops, the application would keep working but will not process any events.
+There are multiple reasons for a subscription to drop. The connection might close due to network issues, the subscription might get overloaded with events, or your event handler might throw an unhandled exception. It is usually a good idea to handle subscription drops and resubscribe when needed, to overcome transient issues. When a subscription drops, the application would keep working but will not process any events.
 :::
 
 @[code{SubscribeToStream}](./sample-code/Subscriptions/CatchUp.cs)
@@ -54,7 +54,7 @@ In this code, we create an instance of `CatchUpSubscriptionSettings`. You can al
 
 ### Subscribing to `$all`
 
-Subscribing to the global event stream gives you a possibility to create read models from many different event streams. It is a powerful method to create, for example, reporting models with aggregated and denormalized data without using common database operations like `JOIN`. You must, however, carefully evaluate your subscription performance, as when you subscribe to `$all`, you'll get absolutely everything what gets appended to the EventStoreDB cluster. You might also need to filter out system events, by checking if event type starts with `$`. In normal applications, you won't need to process system events.
+Subscribing to the global event stream enables you to create read models from many different event streams. It is a powerful method to create, for example, reporting models with aggregated and denormalized data without using common database operations like `JOIN`. You must, however, carefully evaluate your subscription performance, as when you subscribe to `$all`, you'll get absolutely everything what gets appended to the EventStoreDB cluster. You might also need to filter out system events by checking if the event type starts with `$`. In normal applications, you won't need to process system events.
 
 As mentioned before, the checkpoint for `$all` is not a single numeric value, like it is for a single stream. You need to handle the checkpoint with two positions instead: commit and prepare position.
 
@@ -74,7 +74,7 @@ If you need to stop the subscription without closing the connection, you can use
 
 ## Persistent subscriptions
 
-In contrast to volatile and Catch-up types persistent subscriptions are not dropped when connection is closed. Moreover, this subscription type supports the "[competing consumers](https://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html)" messaging pattern and are useful when you need to distribute messages to many workers. EventStoreDB saves the subscription state server-side and allows for at-least-once delivery guarantees across multiple consumers on the same stream. It is possible to have many groups of consumers compete on the same stream, with each group getting an at-least-once guarantee.
+In contrast to volatile and catch-up types, persistent subscriptions are not dropped when the connection is closed. Moreover, this subscription type supports the "[competing consumers](https://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html)" messaging pattern and is useful when you need to distribute messages to many workers. EventStoreDB saves the subscription state server-side and allows for at-least-once delivery guarantees across multiple consumers on the same stream. It is possible to have many groups of consumers compete on the same stream, with each group getting an at-least-once guarantee.
 
 ::: tip
 The Administration UI includes a _Persistent Subscriptions_ section where a user can create, update, delete and view subscriptions and their statuses.
@@ -82,18 +82,18 @@ The Administration UI includes a _Persistent Subscriptions_ section where a user
 
 ### Concept
 
-Persistent subscriptions serve the same purpose as catch-up or volatile subscriptions, but in a different way. All subscriptions aim to deliver events in real-time to connected subscribers. But, unlike other subscription types, persistent subscriptions are maintained by the server. In a way, catch-up and persistent subscriptions are similar. Both have a last known position from where the subscription starts getting events. However, catch-up subscriptions must take care about keeping the last known position on the subscriber side and persistent subscriptions keep the position on the server.
+Persistent subscriptions serve the same purpose as catch-up or volatile subscriptions, but in a different way. All subscriptions aim to deliver events in real-time to connected subscribers. But, unlike other subscription types, persistent subscriptions are maintained by the server. In a way, catch-up and persistent subscriptions are similar. Both have a last known position from where the subscription starts getting events. However, catch-up subscriptions must take care about keeping the last known position on the subscriber side while persistent subscriptions keep the position on the server.
 
 Since it is the server who decides from where the subscription should start receiving events and knows where events are delivered, subscribers that use a persistent subscription can be load-balanced and process events in parallel. In contrast, catch-up subscriptions, which are client-driven, always receive and process events sequentially and can only be load-balanced on the client side. Therefore, persistent subscriptions allow using the competing consumers pattern that is common in the world of message brokers.
 
-In order for the server to load-balance subscribers, it uses the concept of consumer groups. All clients that belong to a single consumer group will get a portion of events and that's how load balancing works inside a group. It is possible to create multiple consumer groups for the same stream, and they will be completely independent of each other, receiving and processing events in their own pace and having their own last known position handled by the server.
+In order for the server to load-balance subscribers, it uses the concept of consumer groups. All clients that belong to a single consumer group will get a portion of events and that's how load balancing works inside a group. It is possible to create multiple consumer groups for the same stream, and they will be completely independent of each other, receiving and processing events at their own pace and having their own last known position handled by the server.
 
 ::: card
 ![Consumer groups](./images/consumer-groups.jpg)
 :::
 
 ::: note
-Just as in the world of message brokers, processing events in a group of consumers running in parallel processes will most likely get evens out of order within a certain window. For example, if a consumer group has ten consumers, ten messages will be distributed among the available consumers, based on the [strategy](#consumer-strategies) of the group. Even though some strategies make an attempt to consistently deliver ordered events to a single consumer, it's done on the best effort basis and there is no guarantee of events coming in order with any strategy.
+Just as in the world of message brokers, processing events in a group of consumers running in parallel processes will most likely get events out of order within a certain window. For example, if a consumer group has ten consumers, ten messages will be distributed among the available consumers, based on the [strategy](#consumer-strategies) of the group. Even though some strategies make an attempt to consistently deliver ordered events to a single consumer, it's done on a best effort basis and there is no guarantee of events coming in order with any strategy.
 :::
 
 ### Creating a subscription group
@@ -119,16 +119,16 @@ var result = await connection.CreatePersistentSubscriptionAsync(
 );
 ```
 
-| Parameter                                 | Description                                          |
-|:------------------------------------------|:-----------------------------------------------------|
-| `string stream`                           | The stream to the persistent subscription is on.     |
-| `string groupName`                        | The name of the subscription group to create.        |
-| `PersistentSubscriptionSettings settings` | The settings to use when creating this subscription. |
-| `UserCredentials credentials`             | The user credentials to use for this operation.      |
+| Parameter                                 | Description                                                     |
+|:------------------------------------------|:----------------------------------------------------------------|
+| `string stream`                           | The name of the stream which the persistent subscription is on. |
+| `string groupName`                        | The name of the subscription group to create.                   |
+| `PersistentSubscriptionSettings settings` | The settings to use when creating this subscription.            |
+| `UserCredentials credentials`             | The user credentials to use for this operation.                 |
 
 ### Connecting to an existing group
 
-Once you have created a subscription group, clients can connect to that subscription group. A subscription in your application should only have the connection in your code, you should assume that the subscription was created via the client API, the restful API, or manually in the UI.
+Once you have created a subscription group, clients can connect to that subscription group. A subscription in your application should only have the connection in your code, and you should assume that the subscription was created via the client API, the restful API, or manually in the UI.
 
 The most important parameter to pass when connecting is the buffer size. This parameter represents how many outstanding messages the server should allow this client. If this number is too small, your subscription will spend much of its time idle as it waits for an acknowledgment to come back from the client. If it's too big, you waste resources and can start causing time out messages depending on the speed of your processing.
 
@@ -147,21 +147,21 @@ var subscription = await connection.ConnectToPersistentSubscriptionAsync(
 );
 ```
 
-| Parameter                     | Description                                                                |
-|:------------------------------|:---------------------------------------------------------------------------|
-| `string stream`               | The stream to the persistent subscription is on.                           |
-| `string groupName`            | The name of the subscription group to connect to.                          |
-| `Action eventAppeared`        | The action to call when an event arrives over the subscription.            |
-| `Action subscriptionDropped`  | The action to call if the subscription is dropped.                         |
-| `UserCredentials credentials` | The user credentials to use for this operation.                            |
-| `int bufferSize`              | The number of in-flight messages this client is allowed.                   |
-| `bool autoAck`                | Whether to automatically acknowledge messages after eventAppeared returns. |
+| Parameter                     | Description                                                                  |
+|:------------------------------|:-----------------------------------------------------------------------------|
+| `string stream`               | The name of the stream which the persistent subscription is on.              |
+| `string groupName`            | The name of the subscription group to connect to.                            |
+| `Action eventAppeared`        | The action to call when an event arrives over the subscription.              |
+| `Action subscriptionDropped`  | The action to call if the subscription is dropped.                           |
+| `UserCredentials credentials` | The user credentials to use for this operation.                              |
+| `int bufferSize`              | The number of in-flight messages this client is allowed.                     |
+| `bool autoAck`                | Whether to automatically acknowledge messages after `eventAppeared` returns. |
 
 ### Acknowledging events
 
-Clients must acknowledge (or not acknowledge) messages in the competing consumer model. If you enable auto-ack the subscription will automatically acknowledge messages once your handler completes them. If you throw an exception, it will shut down your subscription with a message and the uncaught exception.
+Clients must acknowledge (or not acknowledge) messages in the competing consumer model. If you enable auto-ack, the subscription will automatically acknowledge messages once your handler completes them. If you throw an exception, it will shut down your subscription with a message and the uncaught exception.
 
-You can choose to not auto-ack messages. This can be useful when you have multi-threaded processing of messages in your subscriber and need to pass control to something else. There are methods on the subscription object that you can call `Acknowledge,` and `NotAcknowledge` both take a `ResolvedEvent` (the one you processed) both also have overloads for passing and `IEnumerable<ResolvedEvent>`.
+You can choose to not auto-ack messages. This can be useful when you have multi-threaded processing of messages in your subscriber and need to pass control to something else. There are methods on the subscription object that you can call: `Acknowledge` and `NotAcknowledge`. Both take a `ResolvedEvent` (the one you processed) and both also have overloads for passing an `IEnumerable<ResolvedEvent>`.
 
 ### Consumer strategies
 
@@ -183,7 +183,7 @@ This option can be seen as a fall-back scenario for high availability, when a si
 
 For use with an indexing projection such as the system `$by_category` projection.
 
-EventStoreDB inspects event for its source stream id, hashing the id to one of 1024 buckets assigned to individual clients. When a client disconnects its buckets are assigned to other clients. When a client connects, it is assigned some of the existing buckets. This naively attempts to maintain a balanced workload.
+EventStoreDB inspects the event for its source stream id, hashing the id to one of 1024 buckets assigned to individual clients. When a client disconnects its buckets are assigned to other clients. When a client connects, it is assigned some of the existing buckets. This naively attempts to maintain a balanced workload.
 
 The main aim of this strategy is to decrease the likelihood of concurrency and ordering issues while maintaining load balancing. _This is not a guarantee_, and you should handle the usual ordering and concurrency issues.
 
@@ -201,7 +201,7 @@ public Task ReplayParkedMessages(
 
 ### Updating a subscription group
 
-You can edit the settings of an existing subscription group while it is running, you don't need to delete and recreate it to change settings. When you update the subscription group, it resets itself internally dropping the connections and having them reconnect. You must have admin permissions to update a persistent subscription group.
+You can edit the settings of an existing subscription group while it is running instead of deleting the subscription group and recreating it to change its settings. When you update a subscription group, it resets itself internally, dropping the connections and having them reconnect. You must have admin permissions to update a persistent subscription group.
 
 ```csharp
 var settings = PersistentSubscriptionSettings
@@ -218,12 +218,12 @@ var result = await connection.UpdatePersistentSubscriptionAsync(
 If you change settings such as `startFromBeginning`, this doesn't reset the group's checkpoint. If you want to change the current position in an update, you must delete and recreate the subscription group.
 :::
 
-| Parameter                                 | Description                                          |
-|:------------------------------------------|:-----------------------------------------------------|
-| `string stream`                           | The stream to the persistent subscription is on.     |
-| `string groupName`                        | The name of the subscription group to update.        |
-| `PersistentSubscriptionSettings settings` | The settings to use when updating this subscription. |
-| `UserCredentials credentials`             | The user credentials to use for this operation.      |
+| Parameter                                 | Description                                                     |
+|:------------------------------------------|:----------------------------------------------------------------|
+| `string stream`                           | The name of the stream which the persistent subscription is on. |
+| `string groupName`                        | The name of the subscription group to update.                   |
+| `PersistentSubscriptionSettings settings` | The settings to use when updating this subscription.            |
+| `UserCredentials credentials`             | The user credentials to use for this operation.                 |
 
 ### Persistent subscription settings
 
@@ -238,28 +238,28 @@ var settings = PersistentSubscriptionSettings
 
 The following table shows the options you can set on a persistent subscription.
 
-| Member                                   | Description                                                                                                       |
-|:-----------------------------------------|:------------------------------------------------------------------------------------------------------------------|
-| `ResolveLinkTos`                         | Tells the subscription to resolve link events.                                                                    |
-| `DoNotResolveLinkTos`                    | Tells the subscription to not resolve link events.                                                                |
-| `PreferRoundRobin`                       | If possible preference a round robin between the connections with messages (if not possible uses next available). |
-| `PreferDispatchToSingle`                 | If possible preference dispatching to a single connection (if not possible will use next available).              |
-| `StartFromBeginning`                     | Start the subscription from the first event in the stream.                                                        |
-| `StartFrom(int position)`                | Start the subscription from the position-th event in the stream.                                                  |
-| `StartFromCurrent`                       | Start the subscription from the current position.                                                                 |
-| `WithMessageTimeoutOf(TimeSpan timeout)` | Sets the timeout for a client before retrying the message.                                                        |
-| `CheckPointAfter(TimeSpan time)`         | The amount of time the system should try to checkpoint after.                                                     |
-| `MinimumCheckPointCountOf(int count)`    | The minimum number of messages to write a checkpoint for.                                                         |
-| `MaximumCheckPointCountOf(int count)`    | The maximum number of messages not checkpointed before forcing a checkpoint.                                      |
-| `WithMaxRetriesOf(int count)`            | Sets the number of times to retry a message should before considering it a bad message.                           |
-| `WithLiveBufferSizeOf(int count)`        | The size of the live buffer (in memory) before resorting to paging.                                               |
-| `WithReadBatchOf(int count)`             | The size of the read batch when in paging mode.                                                                   |
-| `WithBufferSizeOf(int count)`            | The number of messages to buffer when in paging mode.                                                             |
-| `WithExtraStatistics`                    | Tells the backend to measure timings on the clients so statistics contain histograms of them.                     |
+| Member                                   | Description                                                                                                          |
+|:-----------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
+| `ResolveLinkTos`                         | Tells the subscription to resolve link events.                                                                       |
+| `DoNotResolveLinkTos`                    | Tells the subscription to not resolve link events.                                                                   |
+| `PreferRoundRobin`                       | If possible, prefers a round robin between the connections with messages (Will use next available if not possible).  |
+| `PreferDispatchToSingle`                 | If possible, prefers dispatching to a single connection (Will use next available if not possible).                   |
+| `StartFromBeginning`                     | Starts the subscription from the first event in the stream.                                                          |
+| `StartFrom(int position)`                | Starts the subscription from the position-th event in the stream.                                                    |
+| `StartFromCurrent`                       | Starts the subscription from the current position.                                                                   |
+| `WithMessageTimeoutOf(TimeSpan timeout)` | Sets the timeout for a client before retrying the message.                                                           |
+| `CheckPointAfter(TimeSpan time)`         | The amount of time the system should try to checkpoint after.                                                        |
+| `MinimumCheckPointCountOf(int count)`    | The minimum number of messages to write a checkpoint for.                                                            |
+| `MaximumCheckPointCountOf(int count)`    | The maximum number of messages not checkpointed before forcing a checkpoint.                                         |
+| `WithMaxRetriesOf(int count)`            | Sets the number of times to retry a message should before considering it a bad message.                              |
+| `WithLiveBufferSizeOf(int count)`        | The size of the live buffer (in memory) before resorting to paging.                                                  |
+| `WithReadBatchOf(int count)`             | The size of the read batch when in paging mode.                                                                      |
+| `WithBufferSizeOf(int count)`            | The number of messages to buffer when in paging mode.                                                                |
+| `WithExtraStatistics`                    | Tells the backend to measure timings on the clients so statistics contain histograms of them.                        |
 
 ### Deleting a subscription group
 
-Remove a subscription group with the delete operation. Like the creation of groups, you rarely do this in your runtime code and is undertaken by an administrator running a script.
+The delete operation can be used to remove a subscription group. Like the creation of groups, you rarely do this in your runtime code and is undertaken by an administrator running a script.
 
 ```csharp
 var result = await connection.DeletePersistentSubscriptionAsync(
@@ -267,11 +267,11 @@ var result = await connection.DeletePersistentSubscriptionAsync(
 );
 ```
 
-| Parameter                     | Description                                      |
-|:------------------------------|:-------------------------------------------------|
-| `string stream`               | The stream to the persistent subscription is on. |
-| `string groupName`            | The name of the subscription group to update.    |
-| `UserCredentials credentials` | The user credentials to use for this operation.  |
+| Parameter                     | Description                                                     |
+|:------------------------------|:----------------------------------------------------------------|
+| `string stream`               | The name of the stream which the persistent subscription is on. |
+| `string groupName`            | The name of the subscription group to update.                   |
+| `UserCredentials credentials` | The user credentials to use for this operation.                 |
 
 ### Monitoring persistent subscriptions
 
@@ -279,7 +279,7 @@ The client API includes helper methods that wrap the HTTP API to allow you to mo
 
 #### Create the manager instance
 
-Before accessing any of the methods described below, you need to create an instance of the `PersistentSubscriptionsManager` class. It needs a logger instance and one of the variations of the `EndPoint` abstract class. You would normally use either the `IpEndPoint` or `DnsEndPoint`. Since all HTTP calls would be redirected to the cluster leader, you can use an IP address of any cluster node. When using the `DnsEndPoint`, you can specify the DNS name of the cluster.
+Before accessing any of the methods described below, you need to create an instance of the `PersistentSubscriptionsManager` class. It needs a logger instance and one of the variations of the `EndPoint` abstract class. You would normally use either the `IpEndPoint` or `DnsEndPoint`. Since all HTTP calls would be redirected to the cluster leader, you can use the IP address of any cluster node. When using the `DnsEndPoint`, you can specify the DNS name of the cluster.
 
 For example:
 


### PR DESCRIPTION
Changed: Fix several typos and grammar in the TCP client subscriptions section