### PR TITLE
557 add a note that the peer routes cannot be updated after a peering was created

### DIFF
--- a/docs/cloud/provision/README.md
+++ b/docs/cloud/provision/README.md
@@ -508,8 +508,10 @@ For our example, here is the complete form:
 ![GCP peering - complete form](./images/gcp/gcp-peering-1.png)
 :::
 
-::: note
+::: notes
 Multiple peer routes are useful in case you want to peer with a subnet that has multiple IP ranges (aliases). A typical example would be aif you have a VPC-native GKE cluster, and you need pods in that cluster to work with Event Store Cloud. Then, you need to add the pod IP range to the peer route in addition to the subnet's primary IP range.
+
+After a peering is created, the peer routes cannot be changed. If there is a need to modify them, the peering should be deleted and created again with the updated set of peer routes. This is true even in the cases, where a cloud provider supports dynamic route updates, e.g. in GCP. The reason is that the EventStore automation creates firewall rules for the peer routes at the moment the peering is created. The firewall rules are not updated dynamically to prevent security breaches.
 :::
 
 When you click on the `Create peering` button, you'll be redirected to the peering list screen with the new peering resource being provisioned. After a little while, the status will change to `Intiated`.

--- a/docs/cloud/provision/README.md
+++ b/docs/cloud/provision/README.md
@@ -511,7 +511,10 @@ For our example, here is the complete form:
 ::: note
 Multiple peer routes are useful in case you want to peer with a subnet that has multiple IP ranges (aliases). A typical example would be aif you have a VPC-native GKE cluster, and you need pods in that cluster to work with Event Store Cloud. Then, you need to add the pod IP range to the peer route in addition to the subnet's primary IP range.
 
-After a peering is created, the peer routes cannot be changed. If there is a need to modify them, the peering should be deleted and created again with the updated set of peer routes. This is true even in the cases, where a cloud provider supports dynamic route updates, e.g. in GCP. The reason is that the EventStore automation creates firewall rules for the peer routes at the moment the peering is created. The firewall rules are not updated dynamically to prevent security breaches.
+:::
+
+::: warning
+After you create a peering, you can't change the peer routes. If you would need to modify the routes, delete the peering and create it again with the updated set of peer routes. The limitation applies even in cases where a cloud provider supports dynamic route updates, e.g. in GCP. The reason is that the EventStore automation creates firewall rules for the peer routes when the peering is created. The firewall rules are not updated dynamically to prevent security breaches.
 :::
 
 When you click on the `Create peering` button, you'll be redirected to the peering list screen with the new peering resource being provisioned. After a little while, the status will change to `Intiated`.

--- a/docs/cloud/provision/README.md
+++ b/docs/cloud/provision/README.md
@@ -508,7 +508,7 @@ For our example, here is the complete form:
 ![GCP peering - complete form](./images/gcp/gcp-peering-1.png)
 :::
 
-::: notes
+::: note
 Multiple peer routes are useful in case you want to peer with a subnet that has multiple IP ranges (aliases). A typical example would be aif you have a VPC-native GKE cluster, and you need pods in that cluster to work with Event Store Cloud. Then, you need to add the pod IP range to the peer route in addition to the subnet's primary IP range.
 
 After a peering is created, the peer routes cannot be changed. If there is a need to modify them, the peering should be deleted and created again with the updated set of peer routes. This is true even in the cases, where a cloud provider supports dynamic route updates, e.g. in GCP. The reason is that the EventStore automation creates firewall rules for the peer routes at the moment the peering is created. The firewall rules are not updated dynamically to prevent security breaches.


### PR DESCRIPTION
A note is added to the docs to clarify what is explained in the GitHub issue.