### PR TITLE
Adds 22.10 LTS release to the docs

### DIFF
--- a/import/repos.json
+++ b/import/repos.json
@@ -9,8 +9,12 @@
     "repo": "https://github.com/EventStore/EventStore",
     "branches": [
       {
+        "version": "v22.10",
+        "name": "release/oss-v22.10"
+      },
+      {
         "version": "v21.10",
-        "name": "master"
+        "name": "release/oss-v21.10"
       },
       {
         "version": "v20.10",


### PR DESCRIPTION
Use `release/oss-v21.10` branch for 21.10 docs

This should only be merged after https://github.com/EventStore/EventStore/pull/3693