### PR TITLE
reference up-to-date version of the go library

### DIFF
--- a/docs/clients/grpc/README.md
+++ b/docs/clients/grpc/README.md
@@ -34,7 +34,7 @@ $ dotnet add package EventStore.Client.Grpc.Streams --version 21.2
 :::
 ::: code-group-item Go
 ```:no-line-numbers
-go get github.com/EventStore/EventStore-Client-Go
+go get github.com/EventStore/EventStore-Client-Go/v3/esdb
 ```
 :::
 ::: code-group-item Java


### PR DESCRIPTION
Currently, when following the documentation for the go client, an old version of the client will be downloaded and used by developers. This also leads to a part of the getting started tutorial not working out of the box due to a breaking change in the client library (renamed esdb.ContentTypeJson constant). The referenced samples from the client repository already use the new import path (https://github.com/EventStore/EventStore-Client-Go/blob/master/samples/quickstart.go)