### PR TITLE
Add 23.6 docs, remove 22.6 (DB-340)

### DIFF
--- a/import/repos.json
+++ b/import/repos.json
@@ -9,6 +9,10 @@
     "repo": "https://github.com/EventStore/EventStore",
     "branches": [
       {
+        "version": "v23.6",
+        "name": "release/oss-v23.6"
+      },
+      {
         "version": "v22.10",
         "name": "release/oss-v22.10"
       },
@@ -19,10 +23,6 @@
       {
         "version": "v20.10",
         "name": "release/oss-v20.10"
-      },
-      {
-        "version": "v22.6",
-        "name": "release/oss-v22.6"
       },
       {
         "version": "v5",


### PR DESCRIPTION
Removing 22.6 docs since it is an interim release that has been out of support for a while