### PR TITLE
Allow for 'nightly' in version

### DIFF
--- a/docs/.vuepress/lib/version.ts
+++ b/docs/.vuepress/lib/version.ts
@@ -1,8 +1,12 @@
 const versionRegex = /v((\d+\.)?(\d+\.)?(\*|\d+))/;
+const nightly = "nightly";
 const v = {
     isVersion: (v: string) => versionRegex.test(v),
     parseVersion: (v: string) => versionRegex.exec(v),
     getVersion: (path: string): string | undefined => {
+        if (path.includes(nightly)) {
+            return nightly;
+        }
         const ref = path.split("#")[0];
         const split = ref.split("/");
         return split.find(x => v.isVersion(x));


### PR DESCRIPTION
Some sample files were not found because the version was coming back as `undefined` when loading them. This should fix the `File not found!` issues in some of the nightly docs such as the `docker-compose.yaml` here:

https://developers.eventstore.com/server/nightly/installation.html#quick-start