### PR TITLE
redirect rules for 5.0.8, 5.0.9

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -54,6 +54,8 @@
 /server/v20/server/*                        /server/v20.10/:splat                      301!
 /server/v5/server/*                         /server/v5/:splat                          301!
 /server/5.0.8/server/*                      /server/v5/:splat                          301!
+/server/5.0.9/server/*                      /server/v5/:splat                          301!
+/server/5.0/server/*                        /server/v5/:splat                          301!
 /server/v21.6/*                             /server/v21.10/:splat                      301!
 /server/v22.6/*                             /server/v22.10/:splat                      301!
 /clients/dotnet/5.0/connecting/options.html /clients/dotnet/5.0/connecting.html        301!

--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -56,6 +56,7 @@
 /server/5.0.8/server/*                      /server/v5/:splat                          301!
 /server/5.0.9/server/*                      /server/v5/:splat                          301!
 /server/5.0/server/*                        /server/v5/:splat                          301!
+/server/v21.2/*                             /server/v21.10/:splat                      301!
 /server/v21.6/*                             /server/v21.10/:splat                      301!
 /server/v22.6/*                             /server/v22.10/:splat                      301!
 /clients/dotnet/5.0/connecting/options.html /clients/dotnet/5.0/connecting.html        301!


### PR DESCRIPTION
More redirects

5.0.8 and 5.0.9 to redirect to v5

[DOC-47](https://linear.app/eventstore/issue/DOC-47/v5-redirects)