### PR TITLE
[DOC-29] Redirects for shopping cart sample data

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -252,8 +252,10 @@ server/v5/diagnostics/histograms.html                             /server/v5/dia
 /clients/http-api/v5/samples/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1165.json          /clients/http-api/v5/samples/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1165.json   301!
 /docs/server/v5/http-api/sample-code/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1165.json  /clients/http-api/v5/samples/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1165.json   301!
 /samples/clients/http-api/v5/event.json                                                           /clients/http-api/v5/samples/v5/event.json   301!
+/samples/clients/http-api/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1164.json          /clients/http-api/v5/samples/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1164.json   301!
+/samples/clients/http-api/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1165.json          /clients/http-api/v5/samples/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1165.json   301!
+/samples/clients/http-api/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1166.json          /clients/http-api/v5/samples/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1166.json   301!
 /samples/clients/http-api/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1167.json          /clients/http-api/v5/samples/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1167.json   301!
-
 
 # Other redirects 
 /cloud/quick-start.html                                             /cloud/intro   301!


### PR DESCRIPTION
In the process of copyediting projections.md, I found a few broken links. 

Additional context:
- if the original link in the EventStore repo is `@httpapi/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1164.json`
- config.ts in the documentation repo replaces `@httpapi/` with `/samples/clients/http-api/v5/` making the link `/samples/clients/http-api/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1164.json`
- However, the build puts this file at `/clients/http-api/v5/samples/v5/data/shoppingCart-b989fe21-9469-4017-8d71-9820b8dd1164.json`

Rather than changing the config replace (which may effect more than just these data files), I'm adding the links to the redirects file.