### PR TITLE
Add HTTP API docs for 21+

### DIFF
--- a/import/repos.json
+++ b/import/repos.json
@@ -47,6 +47,22 @@
     "repo": "https://github.com/EventStore/EventStore",
     "branches": [
       {
+        "version": "v23.10",
+        "name": "release/oss-v23.10"
+      },
+      {
+        "version": "v23.6",
+        "name": "release/oss-v23.6"
+      },
+      {
+        "version": "v22.10",
+        "name": "release/oss-v22.10"
+      },
+      {
+        "version": "v21.10",
+        "name": "release/oss-v21.10"
+      },
+      {
         "version": "v5",
         "name": "release/oss-v5"
       }


### PR DESCRIPTION
The HTTP API docs are being generated, but not included to the docs.

Added the necessary version imports for that.