### PR TITLE
grpc-clients: Add User certificates and Observability pages

### DIFF
--- a/docs/.vuepress/configs/sidebar.ts
+++ b/docs/.vuepress/configs/sidebar.ts
@@ -27,6 +27,8 @@ export const en: ESSidebarConfig = {
         "/clients/grpc/subscriptions.md",
         "/clients/grpc/persistent-subscriptions.md",
         "/clients/grpc/projections.md",
+        "/clients/grpc/authentication.md",
+        "/clients/grpc/observability.md",
       ],
     },
   ],

--- a/docs/clients/grpc/authentication.md
+++ b/docs/clients/grpc/authentication.md
@@ -6,13 +6,14 @@ X.509 certificates are digital certificates that use the X.509 public key infras
 
 ### Prerequisites
 
-1. EventStoreDB 24.2.0 or later.
+1. EventStoreDB 24.2.0 or later with commercial license.
 2. A valid x.509 certificate, which can be created using version `1.3` or higher of our [gencert tool](https://github.com/EventStore/es-gencert-cli).
-3. [Enable User Certificates plugin on the server](https://developers.eventstore.com/server/v24.2/configuration.html#plugins-configuration)
+3. The server must run in secure mode. See [Security Options](../../server/v24.2/security.md#security-options) for more information.
+4. [Enable User Certificates plugin on the server](../../server/v24.2/configuration.md#plugins-configuration)
 
 #### Generate User Certificates
 
-The following command uses the [gencert tool](https://github.com/EventStore/es-gencert-cli) to generate a user certificate for the user `admin` with a validity of `10` days:
+The following command uses the [gencert tool](https://github.com/EventStore/es-gencert-cli) to generate a user certificate for the user `admin` that will expire in 10 days:
 
 :::: tabs
 ::: tab Linux and macOS
@@ -36,8 +37,8 @@ The following command uses the [gencert tool](https://github.com/EventStore/es-g
 To connect to EventStoreDB using the x.509 certificate, you need to provide the
 certificate and the private key to the client. If both username/password and
 certificate authentication data are supplied, the client prioritizes user
-credentials for authentication. The client will throw an error if it receives only one component of the
-certificate files (either the certificate or the key), rather than both.
+credentials for authentication. The client will throw an error if the
+certificate and the key are not both provided.
 
 ::: note
 Please note that currently, password-protected private key files are not supported.

--- a/docs/clients/grpc/authentication.md
+++ b/docs/clients/grpc/authentication.md
@@ -1,0 +1,68 @@
+﻿# Authentication
+
+## Authenticate Using x.509 Certificates
+
+X.509 certificates are digital certificates that use the X.509 public key infrastructure (PKI) standard to verify the identity of clients and servers. They play a crucial role in establishing a secure connection by providing a way to authenticate identities and establish trust.
+
+### Prerequisites
+
+1. EventStoreDB 24.2.0 or later.
+2. A valid x.509 certificate, which can be created using version `1.3` or higher of our [gencert tool](https://github.com/EventStore/es-gencert-cli).
+3. [Enable User Certificates plugin on the server](https://developers.eventstore.com/server/v24.2/configuration.html#plugins-configuration)
+
+#### Generate User Certificates
+
+The following command uses the [gencert tool](https://github.com/EventStore/es-gencert-cli) to generate a user certificate for the user `admin` with a validity of `10` days:
+
+:::: tabs
+::: tab Linux and macOS
+
+```shell
+./es-gencert-cli create-user -username admin -days 10 -ca-certificate ./es-ca/ca.crt -ca-key ./es-ca/ca.key
+```
+
+:::
+::: tab Windows
+
+```powershell
+.\es-gencert-cli.exe create-user -username admin -days 10 -ca-certificate ./es-ca/ca.crt -ca-key ./es-ca/ca.key
+```
+
+:::
+::::
+
+### Connect to EventStoreDB using the x.509 certificate
+
+To connect to EventStoreDB using the x.509 certificate, you need to provide the
+certificate and the private key to the client. If both username/password and
+certificate authentication data are supplied, the client prioritizes user
+credentials for authentication. The client will throw an error if it receives only one component of the
+certificate files (either the certificate or the key), rather than both.
+
+::: note
+Please note that currently, password-protected private key files are not supported.
+:::
+
+The client supports the following parameters:
+
+| Parameter      | Description                                                                    |
+| -------------- | ------------------------------------------------------------------------------ |
+| `userCertFile` | The file containing the X.509 user certificate in PEM format.                  |
+| `userKeyFile`  | The file containing the user certificate’s matching private key in PEM format. |
+
+To authenticate, include these two parameters in your connection string or constructor when initializing the client.
+
+:::: code-group
+::: code-group-item JavaScript
+@[code{client-with-user-certificates}](@grpc:user-certificates.js)
+:::
+::: code-group-item TypeScript
+@[code{client-with-user-certificates}](@grpc:user-certificates.ts)
+:::
+::: code-group-item Java
+@[code{client-with-user-certificates}](@grpc:authentication/UserCertificate.java)
+:::
+::: code-group-item C#
+@[code{client-with-user-certificates}](@grpc:user-certificates/Program.cs)
+:::
+::::

--- a/docs/clients/grpc/observability.md
+++ b/docs/clients/grpc/observability.md
@@ -1,22 +1,22 @@
 # Observability
 
-The EventStoreDB gRPC clients are designed with observability in mind, offering support for OpenTelemetry. This integration provides a set of distributed traces, enabling developers to gain deeper insights into their system.
+The EventStoreDB gRPC clients are designed with observability in mind, offering
+support for OpenTelemetry. This integration provides a set of distributed
+traces, enabling developers to gain deeper insights into their system.
 
 ::: warning
-Currently not all clients have support for observability using OpenTelemetry.
+Currently, OpenTelemetry observability support is not available for all
+clients. Moreover, instrumentation is only provided for append and
+subscribe operations, which includes both 'Catchup' and 'Persistent' modes.
 :::
 
-::: note
-Only the append and subscribe (Catchup and Persistent) operations are instrumented.
-:::
+You can click on the links below to view the full code for each client:
 
-## Traces
+- [NodeJS](https://github.com/EventStore/EventStore-Client-NodeJS/blob/master/packages/test/src/samples/opentelemetry.ts)
+- [Java](https://github.com/EventStore/EventStoreDB-Client-Java/blob/trunk/db-client-java/src/test/java/com/eventstore/dbclient/samples/opentelemetry/Instrumentation.java)
+- [C#](https://github.com/EventStore/EventStore-Client-Dotnet/blob/master/samples/diagnostics/Program.cs)
 
-Traces provides a clear picture of how operations are carried out in a distributed system, making it easier to maintain and enhance the system over time. Traces from the clients can be exported to any compatible collector that supports the OpenTelemetry protocol (OTLP).
-
-For guidance on setting up and utilizing tracing, refer to the [OpenTelemetry](https://opentelemetry.io/) documentation.
-
-### Install Required Packages
+## Required Packages
 
 :::: code-group
 ::: code-group-item JavaScript
@@ -59,13 +59,11 @@ dotnet add package EventStore.Client.Extensions.OpenTelemetry
 :::
 ::::
 
-You can click on the links below to view the full code for each client:
+## Instrumentation
 
-- [NodeJS](https://github.com/EventStore/EventStore-Client-NodeJS/blob/master/packages/test/src/samples/opentelemetry.ts)
-- [Java](https://github.com/EventStore/EventStoreDB-Client-Java/blob/trunk/db-client-java/src/test/java/com/eventstore/dbclient/samples/opentelemetry/Instrumentation.java)
-- [C#](https://github.com/EventStore/EventStore-Client-Dotnet/blob/master/samples/diagnostics/Program.cs)
-
-### Register Instrumentation
+To emit trace data, you must first install and use the dedicated package, as instructed in the
+[Required Packages](./observability.md#required-packages) section, if provided. This package
+includes the necessary instrumentation that needs to be registered with the client.
 
 :::: code-group
 ::: code-group-item JavaScript
@@ -75,6 +73,7 @@ You can click on the links below to view the full code for each client:
 @[code{register-instrumentation}](@grpc:opentelemetry.ts)
 :::
 ::: code-group-item Java
+// Instrumentation is enabled by default in the Java client. 
 @[code{register-instrumentation}](@grpc:opentelemetry/Instrumentation.java)
 :::
 ::: code-group-item C#
@@ -82,13 +81,69 @@ You can click on the links below to view the full code for each client:
 :::
 ::::
 
-### With Exporters
+## Traces
 
-You can set up various exporters to send traces to different destinations. Additionally, you have the option to export these traces to a collector of your choice, such as [Jaeger](https://www.jaegertracing.io/) or [Seq](https://datalust.co/seq).
+Traces provide a clear picture of how operations are carried out in a
+distributed system, making it easier to maintain and enhance the system over
+time. Traces from the clients can be exported to any compatible collector that
+supports the OpenTelemetry protocol (OTLP).
 
-For instance, if you choose to use Jaeger as your exporter, you can view your traces in the Jaeger UI, which provides a powerful interface for querying and visualizing your trace data.
+In order for the client to emit traces, you need to need to enable
+instrumentation as described in
+[Instrumentation](./observability.md#instrumentation).
 
-The code snippets below demonstrate how to set up one or more exporters for each client:
+For more guidance on setting up and utilizing tracing, refer to the
+[OpenTelemetry](https://opentelemetry.io/) documentation.
+
+An example of a trace is shown below:
+
+```bash
+Activity.TraceId:            8da04787239dbb85c1f9c6fba1b1f0d6
+Activity.SpanId:             4352ec4a66a20b95
+Activity.TraceFlags:         Recorded
+Activity.ActivitySourceName: eventstoredb
+Activity.DisplayName:        streams.append
+Activity.Kind:               Client
+Activity.StartTime:          2024-05-29T06:50:41.2519016Z
+Activity.Duration:           00:00:00.1500707
+Activity.Tags:
+    db.eventstoredb.stream: d7caa2a5-1e19-4108-9541-58d5fba02d42
+    server.address: localhost
+    server.port: 2113
+    db.system: eventstoredb
+    db.operation: streams.append
+StatusCode: Ok
+Resource associated with Activity:
+    service.name: sample
+    service.instance.id: 7316ef20-c354-4e64-97da-c1b99c2c28b0
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.language: dotnet
+    telemetry.sdk.version: 1.8.1
+```
+
+In this case, the trace is for an append operation on a stream. The trace
+includes the trace ID, span ID, trace flags, activity source name, display name,
+kind, start time, duration, tags, status code, and resource associated with the
+activity.
+
+::: note
+The structure of the trace may vary depending on the client and the operation
+being performed but will generally include the same information.
+:::
+
+## Exporting Traces
+
+You can set up various exporters to send traces to different destinations.
+Additionally, you have the option to export these traces to a collector of your
+choice, such as [Jaeger](https://www.jaegertracing.io/) or
+[Seq](https://datalust.co/seq).
+
+For instance, if you choose to use Jaeger as your backend of choice, you can
+view your traces in the Jaeger UI, which provides a powerful interface for
+querying and visualizing your trace data.
+
+The code snippets below demonstrate how to set up one or more exporters for each
+client:
 
 :::: code-group
 ::: code-group-item JavaScript
@@ -104,3 +159,7 @@ The code snippets below demonstrate how to set up one or more exporters for each
 @[code{setup-exporter}](@grpc:diagnostics/Program.cs)
 :::
 ::::
+
+For more details on configuring exporters for specific programming languages,
+refer to the [OpenTelemetry](https://opentelemetry.io/docs/languages/)
+documentation.

--- a/docs/clients/grpc/observability.md
+++ b/docs/clients/grpc/observability.md
@@ -1,0 +1,106 @@
+# Observability
+
+The EventStoreDB gRPC clients are designed with observability in mind, offering support for OpenTelemetry. This integration provides a set of distributed traces, enabling developers to gain deeper insights into their system.
+
+::: warning
+Currently not all clients have support for observability using OpenTelemetry.
+:::
+
+::: note
+Only the append and subscribe (Catchup and Persistent) operations are instrumented.
+:::
+
+## Traces
+
+Traces provides a clear picture of how operations are carried out in a distributed system, making it easier to maintain and enhance the system over time. Traces from the clients can be exported to any compatible collector that supports the OpenTelemetry protocol (OTLP).
+
+For guidance on setting up and utilizing tracing, refer to the [OpenTelemetry](https://opentelemetry.io/) documentation.
+
+### Install Required Packages
+
+:::: code-group
+::: code-group-item JavaScript
+
+```
+# Yarn
+$ yarn add @eventstore/opentelemetry
+
+# NPM
+$ npm install --save @eventstore/opentelemetry
+```
+
+:::
+::: code-group-item TypeScript
+
+```
+# TypeScript Declarations are included in the package.
+
+# Yarn
+$ yarn add @eventstore/opentelemetry
+
+# NPM
+$ npm install --save @eventstore/opentelemetry
+```
+
+:::
+::: code-group-item Java
+
+```
+OpenTelemetry is supported out of the box in the Java client.
+```
+
+:::
+::: code-group-item C#
+
+```bash
+dotnet add package EventStore.Client.Extensions.OpenTelemetry
+```
+
+:::
+::::
+
+You can click on the links below to view the full code for each client:
+
+- [NodeJS](https://github.com/EventStore/EventStore-Client-NodeJS/blob/master/packages/test/src/samples/opentelemetry.ts)
+- [Java](https://github.com/EventStore/EventStoreDB-Client-Java/blob/trunk/db-client-java/src/test/java/com/eventstore/dbclient/samples/opentelemetry/Instrumentation.java)
+- [C#](https://github.com/EventStore/EventStore-Client-Dotnet/blob/master/samples/diagnostics/Program.cs)
+
+### Register Instrumentation
+
+:::: code-group
+::: code-group-item JavaScript
+@[code{register-instrumentation}](@grpc:opentelemetry.js)
+:::
+::: code-group-item TypeScript
+@[code{register-instrumentation}](@grpc:opentelemetry.ts)
+:::
+::: code-group-item Java
+@[code{register-instrumentation}](@grpc:opentelemetry/Instrumentation.java)
+:::
+::: code-group-item C#
+@[code{register-instrumentation}](@grpc:diagnostics/Program.cs)
+:::
+::::
+
+### With Exporters
+
+You can set up various exporters to send traces to different destinations. Additionally, you have the option to export these traces to a collector of your choice, such as [Jaeger](https://www.jaegertracing.io/) or [Seq](https://datalust.co/seq).
+
+For instance, if you choose to use Jaeger as your exporter, you can view your traces in the Jaeger UI, which provides a powerful interface for querying and visualizing your trace data.
+
+The code snippets below demonstrate how to set up one or more exporters for each client:
+
+:::: code-group
+::: code-group-item JavaScript
+@[code{setup-exporter}](@grpc:opentelemetry.js)
+:::
+::: code-group-item TypeScript
+@[code{setup-exporter}](@grpc:opentelemetry.ts)
+:::
+::: code-group-item Java
+@[code{setup-exporter}](@grpc:opentelemetry/Instrumentation.java)
+:::
+::: code-group-item C#
+@[code{setup-exporter}](@grpc:diagnostics/Program.cs)
+:::
+::::


### PR DESCRIPTION
The gRPC clients recently added support for X509 user certificates for authentication and distributed tracing using OpenTelemetry.

This PR aims to add documentation for these features in the gRPC clients page section.