### PR TITLE
Secure Python Client Connection Setup and CA Certificate Configuration

### DIFF
--- a/docs/clients/grpc/README.md
+++ b/docs/clients/grpc/README.md
@@ -120,6 +120,14 @@ First, create a client and get it connected to the database.
 
 The client instance can be used as a singleton across the whole application. It doesn't need to open or close the connection.
 
+::: tip
+
+When using the Python client to connect to a 3-node cluster, ensure that your client has access to the root CA certificate.
+
+Include the certificate in the connection string to establish a secure connection.
+
+:::
+
 ### Creating an event
 
 You can write anything to EventStoreDB as events. The client needs a byte array as the event payload. Normally, you'd use a serialized object, and it's up to you to choose the serialization method.


### PR DESCRIPTION
When trying to connect to a 3 node cluster on docker using the python client while tls was set to True, I was experiencing an SSL HANDSHAKE error more detail shown below:

""UNKNOWN:Error received from peer  {created_time:"2024-07-29T09:05:29.2486273+00:00", grpc_status:14, grpc_message:"failed to connect to all addresses; last error: UNKNOWN: ipv4:127.0.0.1:2113: Ssl handshake failed: SSL_ERROR_SSL: error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED"}""

In order to solve this, I needed to provide the root ca in the connection string so that the server can decrypt the data to read it.

Code Here:
```
def get_ca_certificate() -> str:
    ca_cert_path = os.path.join(
        os.path.dirname(os.path.dirname(__file__)), "C:/Users/jusbe/Desktop/certs/ca/ca.crt"
    )
    with open(ca_cert_path, "r") as f:
        return f.read()


def get_server_certificate(grpc_target: str) -> str:
    return ssl.get_server_certificate(
        addr=cast(Tuple[str, int], grpc_target.split(":")),
    )


def append_events():
    client = EventStoreDBClient(
        uri="esdb://admin:changeit@localhost:2112?Tls=true",
        root_certificates=get_ca_certificate()
    )
```