### PR TITLE
Fix command to install go client dependency

### DIFF
--- a/docs/clients/grpc/README.md
+++ b/docs/clients/grpc/README.md
@@ -64,7 +64,7 @@ $ dotnet add package EventStore.Client.Grpc.Streams --version 23.1.0
 :::
 ::: code-group-item Go
 ```:no-line-numbers
-go get github.com/EventStore/EventStore-Client-Go/v3.2.0/esdb
+go get github.com/EventStore/EventStore-Client-Go/v4
 ```
 :::
 ::: code-group-item Rust


### PR DESCRIPTION
The Go command used to install the Go client in https://developers.eventstore.com/clients/grpc/#required-packages 
- does not install v3.2.0 (see snippet attached)
- does not point to the latest release of the Go client

This PR fixes both of the above.

Before:
```
$ go get github.com/EventStore/EventStore-Client-Go/v3.2.0/esdb

go: module github.com/EventStore/EventStore-Client-Go@upgrade found (v1.0.2), but does not contain package github.com/EventStore/EventStore-Client-Go/v3.2.0/esdb
```

After:
```
$ go get github.com/EventStore/EventStore-Client-Go/v4         

go: downloading github.com/EventStore/EventStore-Client-Go/v4 v4.1.0
go: added github.com/EventStore/EventStore-Client-Go/v4 v4.1.0
```