### PR TITLE
Ensure Deep Link Tab Switching Works by Addressing Execution Order

### DIFF
--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -66,6 +66,23 @@ export default defineClientConfig({
         // Router configuration
         addFixedRoute("/http/", `${apiPath}/introduction`);
         addFixedRoute("/cloud/", `/cloud/introduction.html`);
+        router.afterEach(() => {
+            setTimeout(() => { // to ensure this runs after DOM updates
+                try {
+                    const { code } = JSON.parse(localStorage.getItem('VUEPRESS_TAB_STORE'));
+                    if (code) { // If a valid 'code' is found in localStorage
+                        Array.from(document.querySelectorAll('.vp-tab-nav'))
+                            .forEach((button: HTMLButtonElement) => {
+                                if (button.textContent.trim() === code) {
+                                    button.click(); // click the button to switch the tab
+                                }
+                            });
+                    }
+                } catch (_error) {
+                    // Error is ignored
+                }
+            }, 0);
+        });
         addDynamicRoute("/server/:version", to => `/server/${to.params.version}/quick-start/`);
         addDynamicRoute('/client/:lang',
             to => {
@@ -99,5 +116,6 @@ export default defineClientConfig({
             if (route.path !== "/") return;
             // console.log(route.meta._pageChunk.data.frontmatter.head);
         });
+        
     },
 } satisfies ClientConfig);


### PR DESCRIPTION
This PR fixes the issue where deep linking to specific tabs was not working correctly due to the order of execution between the theme's local storage tab handling and the custom redirect logic in `client.ts`.

### Key Changes:
- Added a `router.afterEach` hook to initialize the tab based on the value stored in `VUEPRESS_TAB_STORE` and ensure the correct tab is activated after the route transition.

### Why is this needed?
Previously, the tab state stored in the theme's local storage was being [loaded](https://github.com/pengzhanbo/vuepress-theme-plume/blob/c177fd6917e42218f71845b91dbc397972334405/plugins/plugin-md-power/src/client/components/Tabs.vue#L15) before the custom redirect logic had a chance to run, causing the deep links to fail in activating the correct tab. This fix ensures that the tab is correctly initialized after the route changes, allowing deep linking to work as expected.