### PR TITLE
Fix Escaping of C# Characters in Vue Code Snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ Code can be imported from the samples directory using the `@[code]` directive. T
 @[code{client-with-user-certificates}](@grpc:user-certificates.ts)
 @tab Java
 @[code{client-with-user-certificates}](@grpc:authentication/UserCertificate.java)
-@tab C#
+@tab C##
 @[code{client-with-user-certificates}](@grpc:user-certificates/Program.cs)
 :::
 ```

--- a/docs/clients/grpc/authentication.md
+++ b/docs/clients/grpc/authentication.md
@@ -57,7 +57,7 @@ Check the samples for the following clients:
 @[code{client-with-user-certificates}](@grpc:user-certificates.ts)
 @tab Java
 @[code{client-with-user-certificates}](@grpc:authentication/UserCertificate.java)
-@tab C#
+@tab C##
 @[code{client-with-user-certificates}](@grpc:user-certificates/Program.cs)
 :::
 

--- a/docs/clients/grpc/delete-stream.md
+++ b/docs/clients/grpc/delete-stream.md
@@ -34,7 +34,7 @@ await client.deleteStream(streamName);
 client.deleteStream(streamName, DeleteStreamOptions.get()).get();
 ```
 
-@tab C#
+@tab C##
 
 ```csharp
 await client.DeleteAsync(streamName, StreamState.Any);
@@ -99,7 +99,7 @@ await client.tombstoneStream(streamName);
 client.tombstoneStream(streamName, DeleteStreamOptions.get()).get();
 ```
 
-@tab C#
+@tab C##
 
 ```csharp
 await client.TombstoneAsync(streamName, StreamState.Any);


### PR DESCRIPTION
This PR addresses the issue of improperly escaped C# characters in Vue code snippets. The use of `C##` allows for the correct rendering of code without conflicts with Vue's templating syntax.

### Changes Made
- Updated Vue documentation to use `C##` for escaping C# characters in relevant code snippets.

### Why this change is needed
In Hope Theme of VuePress, the `#` symbol is used to specify values for tabs. When C# code includes `#`, it can conflict with this syntax, leading to rendering issues in the documentation. Using `C##` prevents this conflict and ensures that code snippets are displayed correctly.
https://theme-hope.vuejs.press/guide/markdown/content/tabs.html

### Screenshot
![image](https://github.com/user-attachments/assets/1b804f57-11ae-47d8-aa18-93e66f11c83b)
