### PR TITLE
Fix dark theme background issue for <code> blocks in Ask AI widget

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -80,3 +80,13 @@ body:has(#kapa-widget-container) .vp-back-to-top-button {
 .theme-hope-content:not(.custom)>ul p {
   text-align: left;
 }
+
+html[data-theme='dark'] #kapa-widget-portal {
+  code {
+    background: rgba(127, 127, 127, 0.12);
+  }
+
+  blockquote {
+    border-color: #eee;
+  }
+}


### PR DESCRIPTION
This PR resolves the issue where the `<code>` block in the Ask AI widget is incorrectly styled with a dark background when the dark theme is enabled.

### Problem:
The background and text color of `<code>` blocks in the Ask AI modal are both set to dark colors, making the text unreadable. This issue is caused by the global background color applied when dark mode is enabled by the `vuepress-theme-hope` theme.

![image](https://github.com/user-attachments/assets/4ad3e277-22e4-4a24-9089-654d2272ef1d)

### Cause:
The global dark theme styling comes from the normalize.scss file in the `vuepress-theme-hope` theme, which applies a background color globally when dark mode is enabled: [vuepress-theme-hope reference](https://github.com/vuepress-theme-hope/vuepress-theme-hope/blob/5020cfefc5315fa42a1f2fe230b5502480c9921f/packages/theme/src/client/styles/normalize.scss#L39).

### Solution:
A style override has been applied using `docs/.vuepress/styles/index.scss` to fix the dark theme issue by setting a light background for the `<code>` block inside the Ask Kapa widget. This solution follows the guidelines from the `vuepress-theme-hope` documentation on overriding styles: [vuepress-theme-hope style config guide](https://theme-hope.vuejs.press/config/style.html#index-scss).

![image](https://github.com/user-attachments/assets/ed604522-c081-48b6-b830-0df3e6ae66df)

**Note:** According to the [kapa.ai best practices](https://docs.kapa.ai/integrations/website-widget/tutorials/best-practice-widget-deployment#5-avoid-custom-css), custom CSS for the Ask AI widget is not recommended. This fix respects that guideline by undoing the changes made by the `vuepress-theme-hope` theme without directly customizing the Kapa widget’s CSS.