### PR TITLE
restoring 24.2 documentation

### DIFF
--- a/import/repos.json
+++ b/import/repos.json
@@ -21,6 +21,12 @@
         "startPage": "quick-start/"
       },
       {
+        "version": "v24.2",
+        "name": "release/oss-v24.2",
+        "relativePath": ["server"],
+        "startPage": "quick-start/"
+      },
+      {
         "version": "v23.10",
         "name": "release/oss-v23.10",
         "relativePath": ["server"],


### PR DESCRIPTION
re-adding 24.2 docs based on slack conversation:  https://eventstore.slack.com/archives/C030V9E1YHM/p1732095962413379