### PR TITLE
Fix _redirects issue

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -7,110 +7,110 @@
 # General redirects 
 # Basic format is: from what the browser requests to what we serve
 # 
-/latest.html                           /server/v24.6/quick-start/                            301!
-/latest                                /server/v24.6/quick-start/                            301!
-# /server/latest/*                       /server/v24.2/:splat                      301!
+/latest.html                           /server/v24.6/quick-start/                            301
+/latest                                /server/v24.6/quick-start/                            301
+# /server/latest/*                       /server/v24.2/:splat                      301
 
 # ########################################################################################################################
 # Clients 
 # ########################################################################################################################
 
 ## redirect for internet search on "esdb .net client
-/clients/dotnet/5.0/connecting.html   /clients/grpc/#connecting-to-eventstoredb    301!
+/clients/dotnet/5.0/connecting.html   /clients/grpc/#connecting-to-eventstoredb    301
 
 # ##################################################
 ## TCP Clients
 
-/clients/dotnet/21.2/migration-to-gRPC.html#appending-events       /clients/tcp/dotnet/21.2/migration-to-gRPC.html#appending-events    301!
-/clients/dotnet/5.0/migration-to-gRPC.html#update-the-target-framework /clients/tcp/dotnet/21.2/migration-to-gRPC.html#update-the-target-framework  301!
-/clients/dotnet/5.0/migration-to-gRPC.html    /clients/tcp/dotnet/21.2/migration-to-gRPC.html  301!
+/clients/dotnet/21.2/migration-to-gRPC.html#appending-events       /clients/tcp/dotnet/21.2/migration-to-gRPC.html#appending-events    301
+/clients/dotnet/5.0/migration-to-gRPC.html#update-the-target-framework /clients/tcp/dotnet/21.2/migration-to-gRPC.html#update-the-target-framework  301
+/clients/dotnet/5.0/migration-to-gRPC.html    /clients/tcp/dotnet/21.2/migration-to-gRPC.html  301
 
 ## more TCP Clients redirects
-/samples/clients/dotnet/22.0/*              /clients/tcp/dotnet/21.2                       301!
-/clients/dotnet/5.0/*                       /clients/tcp/dotnet/21.2/:splat                301!
-/clients/dotnet/21.2/*                      /clients/tcp/dotnet/21.2/:splat                301!
-/clients/dotnet/20.10/*                     /clients/tcp/dotnet/21.2/:splat                301!
+/samples/clients/dotnet/22.0/*              /clients/tcp/dotnet/21.2                       301
+/clients/dotnet/5.0/*                       /clients/tcp/dotnet/21.2/:splat                301
+/clients/dotnet/21.2/*                      /clients/tcp/dotnet/21.2/:splat                301
+/clients/dotnet/20.10/*                     /clients/tcp/dotnet/21.2/:splat                301
 
-## /clients/dotnet/*                           /clients/tcp/dotnet/:splat                  301!
+## /clients/dotnet/*                           /clients/tcp/dotnet/:splat                  301
 
 ## TCP Clients from Vuepress v1 to v2
-/clients/dotnet/generated/v20.6.0           /clients/tcp/dotnet/21.2                       301!
+/clients/dotnet/generated/v20.6.0           /clients/tcp/dotnet/21.2                       301
 
-/clients/dotnet/:version/getting-started/*  /clients/tcp/dotnet/:version/:splat            301!
+/clients/dotnet/:version/getting-started/*  /clients/tcp/dotnet/:version/:splat            301
 /clients/dotnet/:version/:firstpart.html    /clients/tcp/dotnet/:version/:firstpart.html   200
-/clients/dotnet/:version/:firstpart/*       /clients/tcp/dotnet/:version/:firstpart.html   301!
+/clients/dotnet/:version/:firstpart/*       /clients/tcp/dotnet/:version/:firstpart.html   301
 
 # ##################################################
 ## gRPC Clients from Vuepress v1 to v2
-/clients/grpc/subscribing-to-streams/persistent-subscriptions.html   /clients/grpc/persistent-subscriptions.html  301!
-/clients/grpc/subscribing-to-streams/*                               /clients/grpc/subscriptions.html             301!
-/clients/grpc/:firstpart/*                                           /clients/grpc/:firstpart.html                301!
+/clients/grpc/subscribing-to-streams/persistent-subscriptions.html   /clients/grpc/persistent-subscriptions.html  301
+/clients/grpc/subscribing-to-streams/*                               /clients/grpc/subscriptions.html             301
+/clients/grpc/:firstpart/*                                           /clients/grpc/:firstpart.html                301
 
 # ##################################################
 # HTTP API from Vuepress v1 to v2
-/server/v5/docs/http-api/                   /clients/http-api/v5/                      301!
-/server/v5/docs/http-api/:firstpart.html    /clients/http-api/v5/                      301!
-/server/v5/docs/http-api/:firstpart/*       /clients/http-api/v5/:firstpart/:splat     301!
-/clients/http-api/v5/:firstpart/:filename.html /clients/http-api/v5/:firstpart/        301!
+/server/v5/docs/http-api/                   /clients/http-api/v5/                      301
+/server/v5/docs/http-api/:firstpart.html    /clients/http-api/v5/                      301
+/server/v5/docs/http-api/:firstpart/*       /clients/http-api/v5/:firstpart/:splat     301
+/clients/http-api/v5/:firstpart/:filename.html /clients/http-api/v5/:firstpart/        301
 
-/clients/http-api/generated/v5/docs/api                            /clients/http-api/v5/api.html   301!
-/clients/http-api/v5/introduction                                  /clients/http-api/v5   301!
+/clients/http-api/generated/v5/docs/api                            /clients/http-api/v5/api.html   301
+/clients/http-api/v5/introduction                                  /clients/http-api/v5   301
 
-/clients/http-api/generated/v5/docs/optional-http-headers                           /clients/http-api/v5/optional-http-headers.html 301!
-/clients/http-api/generated/v5/docs/introduction/deleting-a-stream.html             /clients/http-api/v5/#deleting-a-stream   301!        
-/server/generated/v5/docs/http-api/optimistic-concurrency-and-idempotence.html      /clients/http-api/v5/#optimistic-concurrency-and-idempotence   301!
-/clients/http-api/generated/v5/docs/optional-http-headers/expected-version.html     /clients/http-api/v5/optional-http-headers.html#expected-version   301!
-/clients/http-api/generated/v5/docs/optional-http-headers/requires-master.html      /clients/http-api/v5/optional-http-headers.html#requires-master   301!
-/clients/http-api/generated/v5/docs/optional-http-headers/resolve-linkto.html       /clients/http-api/v5/optional-http-headers.html#resolve-linkto   301!
-/clients/http-api/generated/v5/docs/introduction/reading-streams.html               /clients/http-api/v5/#reading-streams-and-events   301!
-/clients/http-api/generated/v5/docs/introduction/optimistic-concurrency-and-idempotence.html      /clients/http-api/v5/#optimistic-concurrency-and-idempotence   301!
+/clients/http-api/generated/v5/docs/optional-http-headers                           /clients/http-api/v5/optional-http-headers.html 301
+/clients/http-api/generated/v5/docs/introduction/deleting-a-stream.html             /clients/http-api/v5/#deleting-a-stream   301        
+/server/generated/v5/docs/http-api/optimistic-concurrency-and-idempotence.html      /clients/http-api/v5/#optimistic-concurrency-and-idempotence   301
+/clients/http-api/generated/v5/docs/optional-http-headers/expected-version.html     /clients/http-api/v5/optional-http-headers.html#expected-version   301
+/clients/http-api/generated/v5/docs/optional-http-headers/requires-master.html      /clients/http-api/v5/optional-http-headers.html#requires-master   301
+/clients/http-api/generated/v5/docs/optional-http-headers/resolve-linkto.html       /clients/http-api/v5/optional-http-headers.html#resolve-linkto   301
+/clients/http-api/generated/v5/docs/introduction/reading-streams.html               /clients/http-api/v5/#reading-streams-and-events   301
+/clients/http-api/generated/v5/docs/introduction/optimistic-concurrency-and-idempotence.html      /clients/http-api/v5/#optimistic-concurrency-and-idempotence   301
 
-/server/generated/v5/http-api/persistent-subscriptions.html       /clients/http-api/v5/persistent.html   301!
-/server/generated/v5/http-api/reading-subscribing-events.html     /clients/http-api/v5/#reading-an-event-from-a-stream   301! 
-/server/v5/samples/http-api/event.json                            /clients/http-api/v5/api.html   301!
+/server/generated/v5/http-api/persistent-subscriptions.html       /clients/http-api/v5/persistent.html   301
+/server/generated/v5/http-api/reading-subscribing-events.html     /clients/http-api/v5/#reading-an-event-from-a-stream   301 
+/server/v5/samples/http-api/event.json                            /clients/http-api/v5/api.html   301
 
-/server/v5/http-api                                               /clients/http-api/v5/persistent.html   301!
-/server/v5/http-api/persistent/security.html                      /clients/http-api/v5/persistent.html   301!
-/server/v5/http-api/writing-events.html                           /clients/http-api/v5/#writing-metadata  301!
-/server/v5/http-api/reading-subscribing-events.html               /clients/http-api/v5/#reading-an-event-from-a-stream   301!
-/server/generated/v5/docs/http-api/optional-http-headers          /clients/http-api/v5/optional-http-headers.html 301!
+/server/v5/http-api                                               /clients/http-api/v5/persistent.html   301
+/server/v5/http-api/persistent/security.html                      /clients/http-api/v5/persistent.html   301
+/server/v5/http-api/writing-events.html                           /clients/http-api/v5/#writing-metadata  301
+/server/v5/http-api/reading-subscribing-events.html               /clients/http-api/v5/#reading-an-event-from-a-stream   301
+/server/generated/v5/docs/http-api/optional-http-headers          /clients/http-api/v5/optional-http-headers.html 301
 
-/server/5.0.8/http-api/writing-events.html                        /clients/http-api/v5/#writing-metadata  301!
-/server/5.0.8/http-api/stream-metadata.html                       /clients/http-api/v5/#stream-metadata   301!
-/server/5.0.9/http-api                                            /clients/http-api/v5   301!
+/server/5.0.8/http-api/writing-events.html                        /clients/http-api/v5/#writing-metadata  301
+/server/5.0.8/http-api/stream-metadata.html                       /clients/http-api/v5/#stream-metadata   301
+/server/5.0.9/http-api                                            /clients/http-api/v5   301
 
 # ##################################################
 # General clients redirect 
 # This rule should be last in this clients list otherwise it takes precedence.
 # ##################################################
-/clients                                                            /clients/grpc   301!
+/clients                                                            /clients/grpc   301
 
 # ########################################################################################################################
 # Cloud 
 # ########################################################################################################################
 
-/cloud/quick-start.html                     /cloud/introduction.html   301!
+/cloud/quick-start.html                     /cloud/introduction.html   301
 
 ## Cloud from Vuepress v1 to v2
-/cloud/provision/cloud-instance-guidance/   /cloud/provision/#cloud-instance-sizing-guide 301!
-/cloud/:firstpart/:filename.html            /cloud/:firstpart/                            301!
-/cloud/:firstpart/:secondpart/              /cloud/:firstpart/                            301!
+/cloud/provision/cloud-instance-guidance/   /cloud/provision/#cloud-instance-sizing-guide 301
+/cloud/:firstpart/:filename.html            /cloud/:firstpart/                            301
+/cloud/:firstpart/:secondpart/              /cloud/:firstpart/                            301
 
 ## Cloud docs deep links
-/cloud/provision/aws/network                /cloud/provision/aws.html#create-a-network            301!
-/cloud/provision/aws/cluster                /cloud/provision/aws.html#deploy-a-managed-instance   301!
-/cloud/provision/aws/peering                /cloud/provision/aws.html#network-peering             301!
-/cloud/provision/aws/regions                /cloud/provision/aws.html#available-regions           301!
+/cloud/provision/aws/network                /cloud/provision/aws.html#create-a-network            301
+/cloud/provision/aws/cluster                /cloud/provision/aws.html#deploy-a-managed-instance   301
+/cloud/provision/aws/peering                /cloud/provision/aws.html#network-peering             301
+/cloud/provision/aws/regions                /cloud/provision/aws.html#available-regions           301
 
-/cloud/provision/azure/network              /cloud/provision/azure.html#create-a-network          301!
-/cloud/provision/azure/cluster              /cloud/provision/azure.html#deploy-a-managed-instance 301!
-/cloud/provision/azure/peering              /cloud/provision/azure.html#network-peering           301!
-/cloud/provision/azure/regions              /cloud/provision/azure.html#available-regions         301!
+/cloud/provision/azure/network              /cloud/provision/azure.html#create-a-network          301
+/cloud/provision/azure/cluster              /cloud/provision/azure.html#deploy-a-managed-instance 301
+/cloud/provision/azure/peering              /cloud/provision/azure.html#network-peering           301
+/cloud/provision/azure/regions              /cloud/provision/azure.html#available-regions         301
 
-/cloud/provision/gcp/network                /cloud/provision/gcp.html#create-a-network          301!
-/cloud/provision/gcp/cluster                /cloud/provision/gcp.html#deploy-a-managed-instance 301!
-/cloud/provision/gcp/peering                /cloud/provision/gcp.html#network-peering           301!
-/cloud/provision/gcp/regions                /cloud/provision/gcp.html#available-regions         301!
+/cloud/provision/gcp/network                /cloud/provision/gcp.html#create-a-network          301
+/cloud/provision/gcp/cluster                /cloud/provision/gcp.html#deploy-a-managed-instance 301
+/cloud/provision/gcp/peering                /cloud/provision/gcp.html#network-peering           301
+/cloud/provision/gcp/regions                /cloud/provision/gcp.html#available-regions         301
 
 
 # ########################################################################################################################
@@ -118,25 +118,25 @@
 # ########################################################################################################################
 
 ## Database from Vuepress v1 to v2
-/server/:version/introduction/              /server/:version/                          301!
-/server/:version/docs/*                     /server/:version/:splat                    301!
+/server/:version/introduction/              /server/:version/                          301
+/server/:version/docs/*                     /server/:version/:splat                    301
 
 # ########################################################################################################################
 ## Server versions - latest and LTS
-/server/v24.2/*                             /server/v24.6/quick-start/                 301!
-/server/v23.6/*                             /server/v23.10/quick-start/                301!
-/server/v22.6/*                             /server/v22.10/:splat                      301!
+/server/v24.2/*                             /server/v24.6/quick-start/                 301
+/server/v23.6/*                             /server/v23.10/quick-start/                301
+/server/v22.6/*                             /server/v22.10/:splat                      301
 
 ## Hope migration
-/connectors/* /server/v24.6/features/connectors/ 301!
-/server/v24.2/metrics.html#opentelemetry-exporter /server/v24.6/diagnostics/integrations.html#opentelemetry-exporter 301!
-/server/v24.2/diagnostics.html#logs-download /server/v24.6/diagnostics/logs.html#logs-download #301!
-/server/v23.10/metrics.html /server/v24.6/diagnostics/metrics.html 301!
+/connectors/* /server/v24.6/features/connectors/ 301
+/server/v24.2/metrics.html#opentelemetry-exporter /server/v24.6/diagnostics/integrations.html#opentelemetry-exporter 301
+/server/v24.2/diagnostics.html#logs-download /server/v24.6/diagnostics/logs.html#logs-download #301
+/server/v23.10/metrics.html /server/v24.6/diagnostics/metrics.html 301
 
 
 # ########################################################################################################################
 # Getting Started 
 # ########################################################################################################################
 
-/getting-started.html                   /getting-started/quickstart/                    301!
-/getting-started/                       /getting-started/quickstart/                    301!
+/getting-started.html                   /getting-started/quickstart/                    301
+/getting-started/                       /getting-started/quickstart/                    301

--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -7,8 +7,8 @@
 # General redirects 
 # Basic format is: from what the browser requests to what we serve
 # 
-/latest.html                           /server/v24.6/quick-start/                            301
-/latest                                /server/v24.6/quick-start/                            301
+/latest.html                           /server/v24.10/quick-start/                            301
+/latest                                /server/v24.10/quick-start/                            301
 # /server/latest/*                       /server/v24.2/:splat                      301
 
 # ########################################################################################################################
@@ -16,7 +16,7 @@
 # ########################################################################################################################
 
 ## redirect for internet search on "esdb .net client
-/clients/dotnet/5.0/connecting.html   /clients/grpc/#connecting-to-eventstoredb    301
+/clients/dotnet/5.0/connecting.html   /clients/grpc/getting-started.html#connecting-to-eventstoredb    301
 
 # ##################################################
 ## TCP Clients
@@ -48,42 +48,44 @@
 
 # ##################################################
 # HTTP API from Vuepress v1 to v2
-/server/v5/docs/http-api/                   /clients/http-api/v5/                      301
-/server/v5/docs/http-api/:firstpart.html    /clients/http-api/v5/                      301
-/server/v5/docs/http-api/:firstpart/*       /clients/http-api/v5/:firstpart/:splat     301
-/clients/http-api/v5/:firstpart/:filename.html /clients/http-api/v5/:firstpart/        301
+/server/v5/docs/http-api/                   /http-api/v5/                      301
+/server/v5/docs/http-api/:firstpart.html    /http-api/v5/                      301
+/server/v5/docs/http-api/:firstpart/*       /http-api/v5/:firstpart/:splat     301
+/clients/http-api/v5/:firstpart/:filename.html /http-api/v5/:firstpart/        301
 
-/clients/http-api/generated/v5/docs/api                            /clients/http-api/v5/api.html   301
-/clients/http-api/v5/introduction                                  /clients/http-api/v5   301
+/clients/http-api/generated/v5/docs/api                            /http-api/v5/api.html   301
+/clients/http-api/v5/introduction                                  /http-api/v5   301
 
-/clients/http-api/generated/v5/docs/optional-http-headers                           /clients/http-api/v5/optional-http-headers.html 301
-/clients/http-api/generated/v5/docs/introduction/deleting-a-stream.html             /clients/http-api/v5/#deleting-a-stream   301        
-/server/generated/v5/docs/http-api/optimistic-concurrency-and-idempotence.html      /clients/http-api/v5/#optimistic-concurrency-and-idempotence   301
-/clients/http-api/generated/v5/docs/optional-http-headers/expected-version.html     /clients/http-api/v5/optional-http-headers.html#expected-version   301
-/clients/http-api/generated/v5/docs/optional-http-headers/requires-master.html      /clients/http-api/v5/optional-http-headers.html#requires-master   301
-/clients/http-api/generated/v5/docs/optional-http-headers/resolve-linkto.html       /clients/http-api/v5/optional-http-headers.html#resolve-linkto   301
-/clients/http-api/generated/v5/docs/introduction/reading-streams.html               /clients/http-api/v5/#reading-streams-and-events   301
-/clients/http-api/generated/v5/docs/introduction/optimistic-concurrency-and-idempotence.html      /clients/http-api/v5/#optimistic-concurrency-and-idempotence   301
+/clients/http-api/generated/v5/docs/optional-http-headers                           /http-api/v5/optional-http-headers.html 301
+/clients/http-api/generated/v5/docs/introduction/deleting-a-stream.html             /http-api/v5/#deleting-a-stream   301        
+/server/generated/v5/docs/http-api/optimistic-concurrency-and-idempotence.html      /http-api/v5/#optimistic-concurrency-and-idempotence   301
+/clients/http-api/generated/v5/docs/optional-http-headers/expected-version.html     /http-api/v5/optional-http-headers.html#expected-version   301
+/clients/http-api/generated/v5/docs/optional-http-headers/requires-master.html      /http-api/v5/optional-http-headers.html#requires-master   301
+/clients/http-api/generated/v5/docs/optional-http-headers/resolve-linkto.html       /http-api/v5/optional-http-headers.html#resolve-linkto   301
+/clients/http-api/generated/v5/docs/introduction/reading-streams.html               /http-api/v5/#reading-streams-and-events   301
+/clients/http-api/generated/v5/docs/introduction/optimistic-concurrency-and-idempotence.html      /http-api/v5/#optimistic-concurrency-and-idempotence   301
 
-/server/generated/v5/http-api/persistent-subscriptions.html       /clients/http-api/v5/persistent.html   301
-/server/generated/v5/http-api/reading-subscribing-events.html     /clients/http-api/v5/#reading-an-event-from-a-stream   301 
-/server/v5/samples/http-api/event.json                            /clients/http-api/v5/api.html   301
+/server/generated/v5/http-api/persistent-subscriptions.html       /http-api/v5/persistent.html   301
+/server/generated/v5/http-api/reading-subscribing-events.html     /http-api/v5/#reading-an-event-from-a-stream   301 
+/server/v5/samples/http-api/event.json                            /http-api/v5/api.html   301
 
-/server/v5/http-api                                               /clients/http-api/v5/persistent.html   301
-/server/v5/http-api/persistent/security.html                      /clients/http-api/v5/persistent.html   301
-/server/v5/http-api/writing-events.html                           /clients/http-api/v5/#writing-metadata  301
-/server/v5/http-api/reading-subscribing-events.html               /clients/http-api/v5/#reading-an-event-from-a-stream   301
-/server/generated/v5/docs/http-api/optional-http-headers          /clients/http-api/v5/optional-http-headers.html 301
+/server/v5/http-api                                               /http-api/v5/persistent.html   301
+/server/v5/http-api/persistent/security.html                      /http-api/v5/persistent.html   301
+/server/v5/http-api/writing-events.html                           /http-api/v5/#writing-metadata  301
+/server/v5/http-api/reading-subscribing-events.html               /http-api/v5/#reading-an-event-from-a-stream   301
+/server/generated/v5/docs/http-api/optional-http-headers          /http-api/v5/optional-http-headers.html 301
 
-/server/5.0.8/http-api/writing-events.html                        /clients/http-api/v5/#writing-metadata  301
-/server/5.0.8/http-api/stream-metadata.html                       /clients/http-api/v5/#stream-metadata   301
-/server/5.0.9/http-api                                            /clients/http-api/v5   301
+/server/5.0.8/http-api/writing-events.html                        /http-api/v5/#writing-metadata  301
+/server/5.0.8/http-api/stream-metadata.html                       /http-api/v5/#stream-metadata   301
+/server/5.0.9/http-api                                            /http-api/v5   301
+
+/clients/http-api/v5/*                                            /http-api/v5/:splat
 
 # ##################################################
 # General clients redirect 
 # This rule should be last in this clients list otherwise it takes precedence.
 # ##################################################
-/clients                                                            /clients/grpc   301
+/clients                                                            /clients/grpc/getting-started.html   301
 
 # ########################################################################################################################
 # Cloud 
@@ -123,15 +125,15 @@
 
 # ########################################################################################################################
 ## Server versions - latest and LTS
-/server/v24.2/*                             /server/v24.6/quick-start/                 301
+/server/v24.2/*                             /server/v24.10/quick-start/                 301
 /server/v23.6/*                             /server/v23.10/quick-start/                301
 /server/v22.6/*                             /server/v22.10/:splat                      301
 
 ## Hope migration
-/connectors/* /server/v24.6/features/connectors/ 301
-/server/v24.2/metrics.html#opentelemetry-exporter /server/v24.6/diagnostics/integrations.html#opentelemetry-exporter 301
-/server/v24.2/diagnostics.html#logs-download /server/v24.6/diagnostics/logs.html#logs-download #301
-/server/v23.10/metrics.html /server/v24.6/diagnostics/metrics.html 301
+/connectors/* /server/v24.10/features/connectors/ 301
+/server/v24.2/metrics.html#opentelemetry-exporter /server/v24.10/diagnostics/integrations.html#opentelemetry-exporter 301
+/server/v24.2/diagnostics.html#logs-download /server/v24.10/diagnostics/logs.html#logs-download #301
+/server/v23.10/metrics.html /server/v24.10/diagnostics/metrics.html 301
 
 
 # ########################################################################################################################


### PR DESCRIPTION
Remove ! from 301. Cloudflare doesn't like the syntax 301! which was meant to force redirect back in the netlify days.

Btw, cloudflare forces redirects by default anyway so ! is not needed.

Meanwhile, I've updated other redirect links that are either broken or not pointing to the latest version