### PR TITLE
Fix: Correct initial page rendering layout in no-sidebar mode

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -74,3 +74,7 @@ html[data-theme='dark'] #kapa-widget-portal {
     border-color: #eee;
   }
 }
+
+.vp-toc-placeholder {
+  width: 100%;
+}


### PR DESCRIPTION
This PR addresses a rendering issue in layout where new documentation pages initially appear center-aligned before correcting to a proper left-aligned layout upon refresh.

## Root Cause:

<img width="456" alt="image" src="https://github.com/user-attachments/assets/9d04e430-7a32-4f60-b2a1-41d1172d61b4" />

The issue stems from the no-sidebar mode of the Vue Hope theme, where styles for the initial rendering are not applied correctly. As a result, the content briefly defaults to an unstyled centered layout before the correct styling kicks in.

### Changes:
- Fixed CSS for `no-sidebar` mode to apply proper styles at the initial load.

## Before Fix:

https://developers.eventstore.com/client/Go

<img width="732" alt="image" src="https://github.com/user-attachments/assets/39ac098b-1593-4217-bca1-241a351301dc" />


## After Fix:

<img width="1389" alt="image" src="https://github.com/user-attachments/assets/822fcf2f-d068-4b11-b98b-5cec2142a8ec" />