### PR TITLE
Resolve center-alignment issue for  client-side redirects

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -75,6 +75,11 @@ html[data-theme='dark'] #kapa-widget-portal {
   }
 }
 
-.vp-toc-placeholder {
-  width: 100%;
+/* Fix for center-alignment issue on `.not-found` pages */
+.vp-page.not-found .theme-hope-content,
+.vp-page.not-found .vp-breadcrumb,
+.vp-page.not-found .vp-page-title,
+.vp-page.not-found .vp-toc-placeholder {
+  text-align: initial;
+  width: var(--content-width, 740px);
 }


### PR DESCRIPTION
## Problem

Pages that rely on client-side redirects in the Vue Hope theme temporarily display content center-aligned due to the vp-page.not-found class being applied during the initial load. This happens before the redirect logic resolves and the correct content is displayed.

This creates a flickering, inconsistent user experience.

## Changes

- Added CSS to reset the text alignment on affected pages.

## Before
<img width="594" alt="image" src="https://github.com/user-attachments/assets/a3b7873b-0d14-462e-a4d5-dcbd91c180a6" />

## After

<img width="1137" alt="image" src="https://github.com/user-attachments/assets/9a7de56e-c993-4fa0-a971-934710360469" />



Existing 404 pages remain unchanged, as verified in the following screenshot

<img width="1407" alt="image" src="https://github.com/user-attachments/assets/ed70c7c9-389f-4cf9-a394-cf908fbb7d03" />
