### PR TITLE
eventstorecloud_to_kurrentcloud

### DIFF
--- a/docs/cloud/automation/README.md
+++ b/docs/cloud/automation/README.md
@@ -5,6 +5,8 @@ dir:
 
 # Automations
 
+<i>Event Store Cloud has been renamed Kurrent Cloud.  The documentation will be updated over the next few weeks to reflect the update more thoroughly.</i>
+
 In addition to the [Cloud console][cloud console], Event Store Cloud provides an API as well as the following automation tools:
 
 * [Terraform provider][terraform]

--- a/docs/cloud/faq.md
+++ b/docs/cloud/faq.md
@@ -2,6 +2,12 @@
 title: Cloud FAQ
 ---
 
+## Kurrent Cloud
+
+#### Is there a difference between Kurrent Cloud and Event Store Cloud?
+
+Event Store Cloud has been renamed Kurrent Cloud.  The documentation will be updated over the next few weeks to reflect the update more thoroughly.
+
 ## Cluster provisioning
 
 #### Is it possible to change the cluster instance size or topology?

--- a/docs/cloud/integrations/README.md
+++ b/docs/cloud/integrations/README.md
@@ -7,6 +7,8 @@ dir:
 
 # Integrations overview
 
+<i>Event Store Cloud has been renamed Kurrent Cloud.  The documentation will be updated over the next few weeks to reflect the update more thoroughly.</i>
+
 Event Store Cloud offers integrations between internal sources such as cluster health, [issue](#issues) detection, [notifications](#notifications) events, EventStore DB [logs](#logs), EventStore DB [metrics](#metrics) and sinks which include external services such as Slack and Amazon CloudWatch.
 
 ## Integration sources

--- a/docs/cloud/introduction.md
+++ b/docs/cloud/introduction.md
@@ -1,9 +1,11 @@
 ---
-title: Introduction
+title: Introduction to Kurrent Cloud
 order: 1
 ---
 
-## What's Event Store Cloud?
+## What is Kurrent Cloud? (Formerly Event Store Cloud)
+
+<i>Event Store Cloud has been renamed Kurrent Cloud.  The documentation will be updated over the next few weeks to reflect the update more thoroughly.</i>
 
 Event Store Cloud allows you to deploy a managed EventStoreDB cluster in AWS, GCP, and Azure. The cloud cluster is optimized for the specific provider and provisioned as a multi-zone VM set.
 

--- a/docs/cloud/ops/README.md
+++ b/docs/cloud/ops/README.md
@@ -7,6 +7,8 @@ dir:
 
 ## Resizing cluster nodes
 
+<i>Event Store Cloud has been renamed Kurrent Cloud.  The documentation will be updated over the next few weeks to reflect the update more thoroughly.</i>
+
 Clusters can be expanded on-demand, to accommodate database growth, through the [Cloud Console](https://console.eventstore.cloud/) and the [Event Store Cloud CLI](https://github.com/EventStore/esc).
 
 You can choose a larger or smaller node size. See also the cloud [sizing guide](../provision/sizing.md) for general guidance.

--- a/docs/cloud/provision/README.md
+++ b/docs/cloud/provision/README.md
@@ -5,7 +5,9 @@ dir:
     order: 2
 ---
 
-# Event Store Cloud provisioning
+# Kurrent Cloud provisioning
+
+<i>Event Store Cloud has been renamed Kurrent Cloud.  The documentation will be updated over the next few weeks to reflect the update more thoroughly.</i>
 
 Event Store Cloud allows you to provision EventStoreDB clusters in AWS, GCP, and Azure.
 

--- a/docs/cloud/use/README.md
+++ b/docs/cloud/use/README.md
@@ -1,10 +1,12 @@
 ---
-title: Using Event Store Cloud
+title: Using Kurrent Cloud
 dir:
   order: 3
 ---
 
 ## Networking
+
+<i>Event Store Cloud has been renamed Kurrent Cloud.  The documentation will be updated over the next few weeks to reflect the update more thoroughly.</i>
 
 Each major cloud provider implements the concept of a Virtual Private Cloud (VPC). A VPC gives you as the cloud user an isolated private network, to which you attach cloud compute resources (virtual machines, container orchestrators, etc) or managed resources, like database servers. VPCs are always in private network address spaces and therefore not directly accessible from the outside of the VPC without additional configuration and infrastructure.
 


### PR DESCRIPTION
added notes to initial subpages from cloud pages left nav bar that Event Store Cloud had been renamed to Kurrent Cloud.  This update was based on a request from Liz (Bhava):  "[This page](https://developers.eventstore.com/cloud/introduction.html) is linked to from the Kurren Cloud page. Would you be able to make some copy updated here to say "Kurrent Cloud (formerly EventStore Cloud)."  

Ideally, this would go live once we rebrand kurrent.io and the Kurrent Cloud page.  