### PR TITLE
docshomeupdate

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -21,8 +21,8 @@ export default defineUserConfig({
     base: "/",
     dest: "public",
     bundler: viteBundler({viteOptions: {plugins: [vueDevTools(),],}}),
-    title: "EventStoreDB Documentation",
-    description: "The stream database built for Event Sourcing",
+    title: "Kurrent Documentation",
+    description: "Kurrent (formerly Event Store) is the first and only event-native data platform. It is built to store and stream data as events for use in downstream use cases such as advanced analytics, microservices and AI/ML initiatives.",
     define: {
         __VERSIONS__: {
             latest: ver.latest,

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ---
 home: true
-heroText: Event Store Resources
-tagline: Event-native database for storing immutable facts as events, complex event processing, and event-driven architectures.
+heroText: Kurrent Resources
+tagline: Kurrent (formerly Event Store) provides an event-native data platform to store and stream data as events for use in downstream use cases such as advanced analytics, microservices and AI/ML initiatives. 
 actions:
 - text: Get started
   link: /getting-started/quickstart/
@@ -12,7 +12,7 @@ actions:
   link: /clients/grpc/
 
 highlights:
-  - header: Jump start development
+  - header: <div align="center">Jump start development
     highlights:
     - title: Start database in a container
       details: Run <code>docker run eventstore/eventstore:latest --dev</code> to start EventStoreDB in developers mode.
@@ -79,5 +79,5 @@ highlights:
       details: Use EventStoreDB's HTTP API to interact with the database using any language or stack.
       link: /http/
 
-footer: Copyright © Event Store Limited
+footer: Copyright © Kurrent, Inc.
 ---


### PR DESCRIPTION
updated landing page to change Event Store to Kurrent

@alexeyzimarev any thoughts on why "Jump start development" is white, while everything else is the brand shade of light blue while in dark mode?