### PR TITLE
Workaround the Cloudflare 100 redirection limit

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -1,48 +1,41 @@
 # ########################################################################################################################
-# List of redirect rules in Netlify
-# Refer to https://docs.netlify.com/routing/redirects/redirect-options/
+# List of redirect rules in Cloudflare Pages
+# Refer to https://developers.cloudflare.com/pages/configuration/redirects/
 # ########################################################################################################################
 
-# ########################################################################################################################
 # ########################################################################################################################
 # STATIC REDIRECTS
 #
 # This section must precede DYNAMIC REDIRECTS
 # https://developers.cloudflare.com/pages/configuration/redirects/#per-file
 # ########################################################################################################################
-# ########################################################################################################################
 
 
-# ########################################################################################################################
+# ######################
 # General redirects
-# Basic format is: from what the browser requests to what we serve
-#
+# ######################
+
 /latest.html                           /server/v24.10/quick-start/                            301
 /latest                                /server/v24.10/quick-start/                            301
-# /server/latest/*                       /server/v24.2/:splat                      301
 
-# ########################################################################################################################
+# ######################
 # Clients
-# ########################################################################################################################
+# ######################
 
-## redirect for internet search on "esdb .net client
+# redirect for internet search on "esdb .net client
 /clients/dotnet/5.0/connecting.html   /clients/grpc/getting-started.html#connecting-to-eventstoredb    301
 
-# ##################################################
-## TCP Clients
-
+# TCP Clients
 /clients/dotnet/21.2/migration-to-gRPC.html#appending-events       /clients/tcp/dotnet/21.2/migration-to-gRPC.html#appending-events    301
 /clients/dotnet/5.0/migration-to-gRPC.html#update-the-target-framework /clients/tcp/dotnet/21.2/migration-to-gRPC.html#update-the-target-framework  301
 /clients/dotnet/5.0/migration-to-gRPC.html    /clients/tcp/dotnet/21.2/migration-to-gRPC.html  301
 
-## TCP Clients from Vuepress v1 to v2
+# TCP Clients from Vuepress v1 to v2
 /clients/dotnet/generated/v20.6.0           /clients/tcp/dotnet/21.2                       301
 
-# ##################################################
-## gRPC Clients from Vuepress v1 to v2
+# gRPC Clients from Vuepress v1 to v2
 /clients/grpc/subscribing-to-streams/persistent-subscriptions.html   /clients/grpc/persistent-subscriptions.html  301
 
-# ##################################################
 # HTTP API from Vuepress v1 to v2
 /server/v5/docs/http-api/                   /http-api/v5/                      301
 
@@ -72,22 +65,20 @@
 /server/5.0.8/http-api/stream-metadata.html                       /http-api/v5/#stream-metadata   301
 /server/5.0.9/http-api                                            /http-api/v5   301
 
-# ##################################################
 # General clients redirect
 # This rule should be last in this clients list otherwise it takes precedence.
-# ##################################################
 /clients                                                            /clients/grpc/getting-started.html   301
 
-# ########################################################################################################################
+# ######################
 # Cloud
-# ########################################################################################################################
+# ######################
 
 /cloud/quick-start.html                     /cloud/introduction.html   301
 
-## Cloud from Vuepress v1 to v2
+# Cloud from Vuepress v1 to v2
 /cloud/provision/cloud-instance-guidance/   /cloud/provision/#cloud-instance-sizing-guide 301
 
-## Cloud docs deep links
+# Cloud docs deep links
 /cloud/provision/aws/network                /cloud/provision/aws.html#create-a-network            301
 /cloud/provision/aws/cluster                /cloud/provision/aws.html#deploy-a-managed-instance   301
 /cloud/provision/aws/peering                /cloud/provision/aws.html#network-peering             301
@@ -104,60 +95,58 @@
 /cloud/provision/gcp/regions                /cloud/provision/gcp.html#available-regions         301
 
 
-# ########################################################################################################################
+# ######################
 # Db Server
-# ########################################################################################################################
+# ######################
 
-## Hope migration
+# Hope migration
 /server/v24.2/metrics.html#opentelemetry-exporter /server/v24.10/diagnostics/integrations.html#opentelemetry-exporter 301
 /server/v24.2/diagnostics.html#logs-download /server/v24.10/diagnostics/logs.html#logs-download #301
 /server/v23.10/metrics.html /server/v24.10/diagnostics/metrics.html 301
 
 
-# ########################################################################################################################
+# ######################
 # Getting Started
-# ########################################################################################################################
+# ######################
 
 /getting-started.html                   /getting-started/quickstart/                    301
 /getting-started/                       /getting-started/quickstart/                    301
 
 
-# ########################################################################################################################
+
+
+
+
+
+
+
 # ########################################################################################################################
 # DYNAMIC REDIRECTS
 #
 # This section must succeed STATIC REDIRECTS
 # https://developers.cloudflare.com/pages/configuration/redirects/#per-file
 # ########################################################################################################################
-# ########################################################################################################################
 
 
-# ########################################################################################################################
+# ######################
 # Clients
-# ########################################################################################################################
+# ######################
 
-# ##################################################
-## TCP Clients
-
-## more TCP Clients redirects
+# TCP Clients redirects
 /samples/clients/dotnet/22.0/*              /clients/tcp/dotnet/21.2                       301
 /clients/dotnet/5.0/*                       /clients/tcp/dotnet/21.2/:splat                301
 /clients/dotnet/21.2/*                      /clients/tcp/dotnet/21.2/:splat                301
 /clients/dotnet/20.10/*                     /clients/tcp/dotnet/21.2/:splat                301
 
-## /clients/dotnet/*                           /clients/tcp/dotnet/:splat                  301
-
-## TCP Clients from Vuepress v1 to v2
+# TCP Clients from Vuepress v1 to v2
 /clients/dotnet/:version/getting-started/*  /clients/tcp/dotnet/:version/:splat            301
 /clients/dotnet/:version/:firstpart.html    /clients/tcp/dotnet/:version/:firstpart.html   200
 /clients/dotnet/:version/:firstpart/*       /clients/tcp/dotnet/:version/:firstpart.html   301
 
-# ##################################################
-## gRPC Clients from Vuepress v1 to v2
+# gRPC Clients from Vuepress v1 to v2
 /clients/grpc/subscribing-to-streams/*                               /clients/grpc/subscriptions.html             301
 /clients/grpc/:firstpart/*                                           /clients/grpc/:firstpart.html                301
 
-# ##################################################
 # HTTP API from Vuepress v1 to v2
 /server/v5/docs/http-api/:firstpart.html    /http-api/v5/                      301
 /server/v5/docs/http-api/:firstpart/*       /http-api/v5/:firstpart/:splat     301
@@ -165,24 +154,23 @@
 
 /clients/http-api/v5/*                                            /http-api/v5/:splat
 
-# ########################################################################################################################
+# ######################
 # Cloud
-# ########################################################################################################################
+# ######################
 
-## Cloud from Vuepress v1 to v2
+# Cloud from Vuepress v1 to v2
 /cloud/:firstpart/:filename.html            /cloud/:firstpart/                            301
 /cloud/:firstpart/:secondpart/              /cloud/:firstpart/                            301
 
-# ########################################################################################################################
+# ######################
 # Db Server
-# ########################################################################################################################
+# ######################
 
-## Database from Vuepress v1 to v2
+# Database from Vuepress v1 to v2
 /server/:version/introduction/              /server/:version/                          301
 /server/:version/docs/*                     /server/:version/:splat                    301
 
-# ########################################################################################################################
-## Server versions - latest and LTS
+# Server versions - latest and LTS
 /server/v24.2/*                             /server/v24.10/quick-start/                 301
 /server/v23.6/*                             /server/v23.10/quick-start/                301
 /server/v22.6/*                             /server/v22.10/:splat                      301

--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -4,15 +4,25 @@
 # ########################################################################################################################
 
 # ########################################################################################################################
-# General redirects 
+# ########################################################################################################################
+# STATIC REDIRECTS
+#
+# This section must precede DYNAMIC REDIRECTS
+# https://developers.cloudflare.com/pages/configuration/redirects/#per-file
+# ########################################################################################################################
+# ########################################################################################################################
+
+
+# ########################################################################################################################
+# General redirects
 # Basic format is: from what the browser requests to what we serve
-# 
+#
 /latest.html                           /server/v24.10/quick-start/                            301
 /latest                                /server/v24.10/quick-start/                            301
 # /server/latest/*                       /server/v24.2/:splat                      301
 
 # ########################################################################################################################
-# Clients 
+# Clients
 # ########################################################################################################################
 
 ## redirect for internet search on "esdb .net client
@@ -25,39 +35,22 @@
 /clients/dotnet/5.0/migration-to-gRPC.html#update-the-target-framework /clients/tcp/dotnet/21.2/migration-to-gRPC.html#update-the-target-framework  301
 /clients/dotnet/5.0/migration-to-gRPC.html    /clients/tcp/dotnet/21.2/migration-to-gRPC.html  301
 
-## more TCP Clients redirects
-/samples/clients/dotnet/22.0/*              /clients/tcp/dotnet/21.2                       301
-/clients/dotnet/5.0/*                       /clients/tcp/dotnet/21.2/:splat                301
-/clients/dotnet/21.2/*                      /clients/tcp/dotnet/21.2/:splat                301
-/clients/dotnet/20.10/*                     /clients/tcp/dotnet/21.2/:splat                301
-
-## /clients/dotnet/*                           /clients/tcp/dotnet/:splat                  301
-
 ## TCP Clients from Vuepress v1 to v2
 /clients/dotnet/generated/v20.6.0           /clients/tcp/dotnet/21.2                       301
-
-/clients/dotnet/:version/getting-started/*  /clients/tcp/dotnet/:version/:splat            301
-/clients/dotnet/:version/:firstpart.html    /clients/tcp/dotnet/:version/:firstpart.html   200
-/clients/dotnet/:version/:firstpart/*       /clients/tcp/dotnet/:version/:firstpart.html   301
 
 # ##################################################
 ## gRPC Clients from Vuepress v1 to v2
 /clients/grpc/subscribing-to-streams/persistent-subscriptions.html   /clients/grpc/persistent-subscriptions.html  301
-/clients/grpc/subscribing-to-streams/*                               /clients/grpc/subscriptions.html             301
-/clients/grpc/:firstpart/*                                           /clients/grpc/:firstpart.html                301
 
 # ##################################################
 # HTTP API from Vuepress v1 to v2
 /server/v5/docs/http-api/                   /http-api/v5/                      301
-/server/v5/docs/http-api/:firstpart.html    /http-api/v5/                      301
-/server/v5/docs/http-api/:firstpart/*       /http-api/v5/:firstpart/:splat     301
-/clients/http-api/v5/:firstpart/:filename.html /http-api/v5/:firstpart/        301
 
 /clients/http-api/generated/v5/docs/api                            /http-api/v5/api.html   301
 /clients/http-api/v5/introduction                                  /http-api/v5   301
 
 /clients/http-api/generated/v5/docs/optional-http-headers                           /http-api/v5/optional-http-headers.html 301
-/clients/http-api/generated/v5/docs/introduction/deleting-a-stream.html             /http-api/v5/#deleting-a-stream   301        
+/clients/http-api/generated/v5/docs/introduction/deleting-a-stream.html             /http-api/v5/#deleting-a-stream   301
 /server/generated/v5/docs/http-api/optimistic-concurrency-and-idempotence.html      /http-api/v5/#optimistic-concurrency-and-idempotence   301
 /clients/http-api/generated/v5/docs/optional-http-headers/expected-version.html     /http-api/v5/optional-http-headers.html#expected-version   301
 /clients/http-api/generated/v5/docs/optional-http-headers/requires-master.html      /http-api/v5/optional-http-headers.html#requires-master   301
@@ -66,7 +59,7 @@
 /clients/http-api/generated/v5/docs/introduction/optimistic-concurrency-and-idempotence.html      /http-api/v5/#optimistic-concurrency-and-idempotence   301
 
 /server/generated/v5/http-api/persistent-subscriptions.html       /http-api/v5/persistent.html   301
-/server/generated/v5/http-api/reading-subscribing-events.html     /http-api/v5/#reading-an-event-from-a-stream   301 
+/server/generated/v5/http-api/reading-subscribing-events.html     /http-api/v5/#reading-an-event-from-a-stream   301
 /server/v5/samples/http-api/event.json                            /http-api/v5/api.html   301
 
 /server/v5/http-api                                               /http-api/v5/persistent.html   301
@@ -79,24 +72,20 @@
 /server/5.0.8/http-api/stream-metadata.html                       /http-api/v5/#stream-metadata   301
 /server/5.0.9/http-api                                            /http-api/v5   301
 
-/clients/http-api/v5/*                                            /http-api/v5/:splat
-
 # ##################################################
-# General clients redirect 
+# General clients redirect
 # This rule should be last in this clients list otherwise it takes precedence.
 # ##################################################
 /clients                                                            /clients/grpc/getting-started.html   301
 
 # ########################################################################################################################
-# Cloud 
+# Cloud
 # ########################################################################################################################
 
 /cloud/quick-start.html                     /cloud/introduction.html   301
 
 ## Cloud from Vuepress v1 to v2
 /cloud/provision/cloud-instance-guidance/   /cloud/provision/#cloud-instance-sizing-guide 301
-/cloud/:firstpart/:filename.html            /cloud/:firstpart/                            301
-/cloud/:firstpart/:secondpart/              /cloud/:firstpart/                            301
 
 ## Cloud docs deep links
 /cloud/provision/aws/network                /cloud/provision/aws.html#create-a-network            301
@@ -116,7 +105,76 @@
 
 
 # ########################################################################################################################
-# Db Server 
+# Db Server
+# ########################################################################################################################
+
+## Hope migration
+/server/v24.2/metrics.html#opentelemetry-exporter /server/v24.10/diagnostics/integrations.html#opentelemetry-exporter 301
+/server/v24.2/diagnostics.html#logs-download /server/v24.10/diagnostics/logs.html#logs-download #301
+/server/v23.10/metrics.html /server/v24.10/diagnostics/metrics.html 301
+
+
+# ########################################################################################################################
+# Getting Started
+# ########################################################################################################################
+
+/getting-started.html                   /getting-started/quickstart/                    301
+/getting-started/                       /getting-started/quickstart/                    301
+
+
+# ########################################################################################################################
+# ########################################################################################################################
+# DYNAMIC REDIRECTS
+#
+# This section must succeed STATIC REDIRECTS
+# https://developers.cloudflare.com/pages/configuration/redirects/#per-file
+# ########################################################################################################################
+# ########################################################################################################################
+
+
+# ########################################################################################################################
+# Clients
+# ########################################################################################################################
+
+# ##################################################
+## TCP Clients
+
+## more TCP Clients redirects
+/samples/clients/dotnet/22.0/*              /clients/tcp/dotnet/21.2                       301
+/clients/dotnet/5.0/*                       /clients/tcp/dotnet/21.2/:splat                301
+/clients/dotnet/21.2/*                      /clients/tcp/dotnet/21.2/:splat                301
+/clients/dotnet/20.10/*                     /clients/tcp/dotnet/21.2/:splat                301
+
+## /clients/dotnet/*                           /clients/tcp/dotnet/:splat                  301
+
+## TCP Clients from Vuepress v1 to v2
+/clients/dotnet/:version/getting-started/*  /clients/tcp/dotnet/:version/:splat            301
+/clients/dotnet/:version/:firstpart.html    /clients/tcp/dotnet/:version/:firstpart.html   200
+/clients/dotnet/:version/:firstpart/*       /clients/tcp/dotnet/:version/:firstpart.html   301
+
+# ##################################################
+## gRPC Clients from Vuepress v1 to v2
+/clients/grpc/subscribing-to-streams/*                               /clients/grpc/subscriptions.html             301
+/clients/grpc/:firstpart/*                                           /clients/grpc/:firstpart.html                301
+
+# ##################################################
+# HTTP API from Vuepress v1 to v2
+/server/v5/docs/http-api/:firstpart.html    /http-api/v5/                      301
+/server/v5/docs/http-api/:firstpart/*       /http-api/v5/:firstpart/:splat     301
+/clients/http-api/v5/:firstpart/:filename.html /http-api/v5/:firstpart/        301
+
+/clients/http-api/v5/*                                            /http-api/v5/:splat
+
+# ########################################################################################################################
+# Cloud
+# ########################################################################################################################
+
+## Cloud from Vuepress v1 to v2
+/cloud/:firstpart/:filename.html            /cloud/:firstpart/                            301
+/cloud/:firstpart/:secondpart/              /cloud/:firstpart/                            301
+
+# ########################################################################################################################
+# Db Server
 # ########################################################################################################################
 
 ## Database from Vuepress v1 to v2
@@ -131,14 +189,3 @@
 
 ## Hope migration
 /connectors/* /server/v24.10/features/connectors/ 301
-/server/v24.2/metrics.html#opentelemetry-exporter /server/v24.10/diagnostics/integrations.html#opentelemetry-exporter 301
-/server/v24.2/diagnostics.html#logs-download /server/v24.10/diagnostics/logs.html#logs-download #301
-/server/v23.10/metrics.html /server/v24.10/diagnostics/metrics.html 301
-
-
-# ########################################################################################################################
-# Getting Started 
-# ########################################################################################################################
-
-/getting-started.html                   /getting-started/quickstart/                    301
-/getting-started/                       /getting-started/quickstart/                    301


### PR DESCRIPTION
See JIRA for more information (https://eventstore-engineering.atlassian.net/browse/ES-206)

## Background

Docs site uses the Cloudflare pages redirection feature (i.e. the _redirect file) to redirect old links to new. [This feature has a limitation of 2000 static redirections and 100 dynamic redirections](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).

> A project is limited to 2,000 static redirects and 100 dynamic redirects, for a combined total of 2,100 redirects. Each redirect declaration has a 1,000-character limit.

Source: https://developers.cloudflare.com/pages/configuration/redirects/#per-file 

## Cloudflare Dynamic vs Static Redirections

Dynamic redirects are links that includes dynamic elements like “*” and “:” in the source link ([Click here to see what this means](https://developers.cloudflare.com/pages/configuration/redirects/#redirects-and-header-matching)). E.g. 
```
/clients/dotnet/:version/getting-started/*  /clients/tcp/dotnet/:version/:splat            301
```

On the other hand, static redirects are ones that don’t include dynamic elements. Ones that redirect a link directly to another e.g.
```
/clients/dotnet/5.0/migration-to-gRPC.html    /clients/tcp/dotnet/21.2/migration-to-gRPC.html  301
```

## The Cloudflare Redirection Miscount 

There is a cloudflare rule that states that static redirects has to precede dynamic ones in the _redirect file, otherwise static redirects will be counted towards the 100 dynamic redirects  limit.

> Static redirects should appear before dynamic redirects

Source: https://developers.cloudflare.com/pages/configuration/redirects/#per-file 

Currently, static and dynamic links are mixed throughout our _redirect file. And so, even though we only use around 20 dynamic redirects currently, Cloudflare mistakenly thinks we use ~90 ones instead. Leaving us very close to the 100 dynamic redirects limit.

## Why is this Happening Right Now?

- In the past, we don’t have a lot of redirects and so this wasn’t really an issue. 
- Secondly, Cloudflare pages as a host for docs site was introduced around the summer of 2024, and so this is a new limitation that was not in effect until recent.
- Finally, while [broken links are being review](https://eventstore-engineering.atlassian.net/browse/ES-202), it was discovered that there were many redirects that were missing. This increases the number of redirects required and Cloudflare’s limitation means these broken links can not be fixed.

## The Proposed Fix

To fix this, the redirects in our _redirect file should be split into two sections. One for static and the other for dynamic ones. The static ones must be ahead of the dynamic ones.