### PR TITLE
Add redirect dynamic redirect from `latest` to latest server version

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -17,6 +17,7 @@
 
 /latest.html                           /server/v24.10/quick-start/                            301
 /latest                                /server/v24.10/quick-start/                            301
+# Note: make sure to also update the latest version in the dynamic section
 
 # ######################
 # Clients
@@ -238,6 +239,9 @@
 /server/v24.2/*                             /server/v24.10/quick-start/               301
 /server/v24.6/*                             /server/v24.10/quick-start/               301
 /server/v24.10%20Preview%201/*              /server/v24.10/:splat                     301
+
+# latest to latest
+/server/latest/*                            /server/v24.10/:splat                     301
 
 
 # Hope migration


### PR DESCRIPTION
For example from:

`https://fc18f034.documentation-21k.pages.dev/server/latest/security/` 
to 
`https://fc18f034.documentation-21k.pages.dev/server/v24.10/security/`

------------------

With navigator, we link out to docs in various places.

If you connect to a `24.10` server, we link to `[docs.kurrent.io/v24.10/](http://docs.kurrent.io/v24.10/)...` but if we fail to get a server version from your connection we still want to link _somewhere_, so we link to `[docs.kurrent.io/latest/](http://docs.kurrent.io/latest/)...`