### PR TITLE
Show 'x' button on server 23.10 notice for user to close

### DIFF
--- a/docs/.vuepress/configs/plugins/notices.ts
+++ b/docs/.vuepress/configs/plugins/notices.ts
@@ -31,7 +31,7 @@ export const notices: NoticePluginOptions = {
             path: "/server/v23.10/",
             title: "EventStoreDB v23.10",
             content: "EventStoreDB v23.10 nearing end of life. Upgrade to the latest server version.",
-            confirm: true,
+            confirm: false,
             showOnce: true,
             actions: [actionLatest]
         },


### PR DESCRIPTION
Server documentation for v23.10 has a notification box that reminds users that it is nearing the end of life:

<img width="846" alt="image" src="https://github.com/user-attachments/assets/8f4fcc69-bbaa-434e-9af8-b2b7763144f6" />

This box often hovers over and blocks existing content and is not collapsible unless the "View latest server documentation" button is clicked.

Since 23.10 is still supported, we should provide a more intuitive way for users to close this notice by adding a 'x' button to it:

![image](https://github.com/user-attachments/assets/bf5c0429-2c4f-4b40-a52f-1a5bf1ecbc19)

After clicking the 'x' button, the box will not appear again even in subsequent browser sessions.
