### PR TITLE
Add first batch of redirects for cloud docs update Jan 2025

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -119,6 +119,16 @@
 /cloud/use/migration/replicator.html        /cloud/use/migration.html     301
 
 
+# Cloud docs update Jan 2025 (3184c4eda8e2746de38a1659e8db176c3821aa94@documentation)
+/cloud/provision/sizing                     /cloud/ops/sizing.html 
+/cloud/provision/sizing.html                /cloud/ops/sizing.html                            301
+/cloud/provision/aws                        /cloud/getting-started/private_access/aws.html    301
+/cloud/provision/aws.html                   /cloud/getting-started/private_access/aws.html    301
+/cloud/provision/azure                      /cloud/getting-started/private_access/azure.html  301
+/cloud/provision/azure.html                 /cloud/getting-started/private_access/azure.html  301
+/cloud/provision/gcp                        /cloud/getting-started/private_access/gcp.html    301
+/cloud/provision/gcp.html                   /cloud/getting-started/private_access/gcp.html    301
+
 # ######################
 # Db Server
 # ######################


### PR DESCRIPTION
[`/cloud/provision/sizing`](https://58e050fa.documentation-21k.pages.dev/cloud/provision/sizing) & [`/cloud/provision/sizing.html`](https://58e050fa.documentation-21k.pages.dev/cloud/provision/sizing.html) -> `/cloud/ops/sizing.html`
[`/cloud/provision/aws`](https://58e050fa.documentation-21k.pages.dev/cloud/provision/aws) & [`/cloud/provision/aws.html`](https://58e050fa.documentation-21k.pages.dev/cloud/provision/aws.html) -> `/cloud/getting-started/private_access/aws.html`
[`/cloud/provision/azure`](https://58e050fa.documentation-21k.pages.dev/cloud/provision/azure) & [`/cloud/provision/azure.html`](https://58e050fa.documentation-21k.pages.dev/cloud/provision/azure.html)  -> `/cloud/getting-started/private_access/azure.html`
[`/cloud/provision/gcp`](https://58e050fa.documentation-21k.pages.dev/cloud/provision/gcp) & [`/cloud/provision/gcp.html`](https://58e050fa.documentation-21k.pages.dev/cloud/provision/gcp.html) -> `/cloud/getting-started/private_access/gcp.html`


@dgivens Looks like we also need to send `/cloud/use/kubernetes.html` & `/cloud/use/migration.html` somewhere, but couldn't find a relevant section. 