### PR TITLE
github: add CODEOWNERS file to docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @coloradomorrissey, @deflaimun
+* @EventStore/database-mergers @EventStore/documentation @deflaimun

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @coloradomorrissey, @deflaimun


### PR DESCRIPTION
Adds CODEOWNERS file to docs so that in every PR and issue the required people are auto-added to it
[About CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)