### PR TITLE
engine+docs: Broken links

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -50,6 +50,15 @@ export default defineUserConfig({
         md.use(linkCheckPlugin);
         // @ts-ignore
         md.use(dl);
+
+        const originalHighlight = md.options.highlight || ((code, lang, attrs) => code);
+
+        md.options.highlight = (code, lang, attrs) => {
+        if (lang === "env") {
+            lang = "bash";
+        }
+        return originalHighlight(code, lang, attrs);
+        };
     },
     theme: hopeTheme(themeOptions),
     head: [

--- a/docs/tutorials/Encryption-At-Rest.md
+++ b/docs/tutorials/Encryption-At-Rest.md
@@ -9,8 +9,8 @@ The **Encryption-At-Rest** feature provides encryption for EventStoreDB to secur
 
 #### Prerequisites:
 
-* [EventStoreDB 24.10 LTS installed and running.](/server/v24.10/quick-start/installation.html)  
-* [License key](/server/v24.10/quick-start/installation.html#license-keys) for Encryption-At-Rest (a valid license is required to use this feature).  
+* [EventStoreDB 24.10 LTS installed and running.](@server/quick-start/installation.md)  
+* [License key](@server/quick-start/installation.md#license-keys) for Encryption-At-Rest (a valid license is required to use this feature).  
 * Basic understanding of EventStoreDB, encryption principles, and key management.
 
 ### Step 1: Verify license key
@@ -25,7 +25,7 @@ By default, Encryption-At-Rest is bundled with EventStoreDB 24.20 LTS. You can c
 [INF] ClusterVNodeHostedService Loaded SubsystemsPlugin plugin: encryption-at-rest 24.10.0.1316
 ```
 
-Refer to the [log documentation](/server/v24.10/diagnostics/logs.html) for instructions on accessing EventStoreDB logs.
+Refer to the [log documentation](@server/diagnostics/logs.md) for instructions on accessing EventStoreDB logs.
 
 ### Step 3: Generate a master key
 
@@ -44,7 +44,7 @@ Place the generated master key in a secure directory on a **separate drive** fro
 #### Step 4.1: Add the configuration file
 
 1. Navigate to the `config` directory within the EventStoreDB installation.  
-   There are multiple [configuration mechanisms](/server/v24.10/configuration/) available. Since options set in a JSON configuration override those set in a YAML configuration, here is an example using JSON. You can also find a [YAML configuration file example in the documentation](https://developers.eventstore.com/server/v24.10/security/#configuration).   
+   There are multiple [configuration mechanisms](@server/configuration/) available. Since options set in a JSON configuration override those set in a YAML configuration, here is an example using JSON. You can also find a [YAML configuration file example in the documentation](@server/security/#configuration).   
      
    Create a new JSON configuration file (e.g., `encryption-config.json`) with the following content:   
    ```json

--- a/docs/tutorials/Stream_Policy_Authorization.md
+++ b/docs/tutorials/Stream_Policy_Authorization.md
@@ -10,8 +10,8 @@ This feature allows EventStoreDB administrators to define stream access policies
 
 #### Prerequisites
 
-* [EventStoreDB 24.10 LTS installed and running](/server/v24.10/quick-start/installation.html)
-* [License key](/server/v24.10/quick-start/installation.html#license-keys) for Stream Policy Authorization (a valid
+* [EventStoreDB 24.10 LTS installed and running](@server/quick-start/installation.md)
+* [License key](@server/quick-start/installation.md#license-keys) for Stream Policy Authorization (a valid
   license is required to use this feature).
 * Basic understanding of EventStoreDB, stream prefixes, and access control.
 
@@ -29,13 +29,13 @@ EventStoreDB logs. Look for the following log message:
 [INF] AuthorizationPolicyRegistryFactory Loaded Authorization Policy plugin: streampolicy
 ```
 
-Refer to the [log documentation](/server/v24.10/diagnostics/logs.html) for instructions on accessing EventStoreDB logs.
+Refer to the [log documentation](@server/diagnostics/logs.md) for instructions on accessing EventStoreDB logs.
 
 ### Step 3: Enable Stream Policy Authorization
 
 ::: note
 When Stream Policy Authorization is enabled, EventStoreDB will not enforce
-stream [Access Control Lists (ACLs)](/server/v24.10/security/user-authorization.html#access-control-lists).*
+stream [Access Control Lists (ACLs)](@server/security/user-authorization.md#access-control-lists).*
 :::
 
 To enable stream policies, append an event of type `$authorization-policy-changed` to the
@@ -106,7 +106,7 @@ following log messages:
 ```
 
 If no valid license is detected, Stream Policy Authorization logs errors and defaults to the ACL policy settings. Refer
-to the [Stream Policy Authorization documentation](/server/v24.10/security/user-authorization.html#troubleshooting) for
+to the [Stream Policy Authorization documentation](@server/security/user-authorization.md#troubleshooting) for
 a list of potential errors and their resolutions.
 
 ### Step 5: Configure stream policies and rules


### PR DESCRIPTION
This PR assumes that https://github.com/EventStore/documentation/pull/800 has been merged.

- Fixes some broken links in docs. 
- Uses directives for server docs instead of direct links
- Forces the syntax highlighter to use bash to highlight `env` code.
- Modify broken link logic to enforce that links are valid. Check if a directory link has a README.md. 

Preview: https://broken-links.documentation-21k.pages.dev/
Logs: https://dash.cloudflare.com/68591db3c4d2ab7bdd4a3a8d53e86ccb/pages/view/documentation/a051112b-4251-4b26-846d-1cad22f14494