### PR TITLE
engine: change darkmode behavior to toggle

### DIFF
--- a/docs/.vuepress/configs/theme.ts
+++ b/docs/.vuepress/configs/theme.ts
@@ -13,6 +13,7 @@ export const themeOptions: ThemeOptions = {
     sidebar: sidebarEn,
     toc: true,
     pure: false,
+    darkmode:"toggle",
     headerDepth: 3,
     plugins: plugins,
     markdown: {

--- a/docs/.vuepress/configs/theme.ts
+++ b/docs/.vuepress/configs/theme.ts
@@ -1,6 +1,6 @@
 import type {ThemeOptions} from "vuepress-theme-hope";
-import plugins from "./plugins";
 import {navbarEn} from "./navbar";
+import plugins from "./plugins";
 import {sidebarEn} from "./sidebar";
 
 export const themeOptions: ThemeOptions = {
@@ -15,7 +15,7 @@ export const themeOptions: ThemeOptions = {
     pure: false,
     darkmode:"toggle",
     headerDepth: 3,
-    plugins: plugins,
+    plugins,
     markdown: {
         figure: true,
         imgLazyload: true,


### PR DESCRIPTION
This PR changes the behavior of the darkmode button from 'switch' to 'toggle'. 
Right now it's using the "switch" behavior with 3 possible options (auto, dark, light). This can feel confusing as sometimes the user must press the button twice to get to the desired effect.

With the 'toggle' behavior, there's only two possible states, making the light change more seamless. 

For reference, see 
https://theme-hope.vuejs.press/guide/interface/darkmode.html

Preview: https://dark-mode-toggle.documentation-21k.pages.dev/