### PR TITLE
github: change codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @EventStore/database-mergers @EventStore/documentation @deflaimun
+* @EventStore/documentation


### PR DESCRIPTION
## Description

Now that I'm in the organization, we don't need to keep a separate entry for codeowners for my name. 

## Page previews

<!-- Add the specific pages that your PR changes here -->

