### PR TITLE
Revert session id change

### DIFF
--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -49,12 +49,12 @@ const reload = () => {
 
 const leave = (to: RouteLocationNormalized, from: RouteLocationNormalized) => {
     if (from.path !== to.path && typeof window !== "undefined" && window.analytics !== undefined) {
-        const sessionId = (typeof window.posthog !== "undefined") ? window.posthog.getSessionId() : null;
+        // const sessionId = (typeof window.posthog !== "undefined") ? window.posthog.getSessionId() : null;
         window.analytics.track({
             event: "$pageleave",
             properties: {
                 $host: window.location.hostname,
-                $session_id: sessionId
+                // $session_id: sessionId
             }
         });
     }

--- a/docs/.vuepress/public/js/snippet.js
+++ b/docs/.vuepress/public/js/snippet.js
@@ -94,7 +94,7 @@
                     site: "docs",
                     title: "Home",
                     $host: window.location.hostname,
-                    $session_id: posthog.getSessionId(),
+                    // $session_id: posthog.getSessionId(),
                 })
             }
         });


### PR DESCRIPTION
## Description

Posthog seems not to be available so getting session id from it doesn't work and crashes the navigation. Reverting the previous change until we figure out how to solve it properly.
