### PR TITLE
github: makes gh action more robust

### DIFF
--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -6,24 +6,28 @@ on:
       - master
 
 jobs:
-  deploy:
-    name: Build and Deploy
+  build:
+    name: Build Website
     runs-on: ubuntu-latest
     env:
-      ALGOLIA_APPLICATION_ID: ${{ secrets.ALGOLIA_APPLICATION_ID }}
-      ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-      ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
       NODE_OPTIONS: --max_old_space_size=8192
-    permissions:
-      contents: read
-      deployments: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: pnpm install
       - name: Build website
-        run: pnpm run build-prod
+        run: |
+          set -e
+          pnpm run build-prod
+
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ success() }}
+    steps:
+      - uses: actions/checkout@v4
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
## Description

On this action https://github.com/EventStore/documentation/actions/runs/14066350433 we noticed that the build did not failed and a corrupt version of the website was published, even though it shouldn't. This change modifies the GH action making it more robust, splitting into a 2-step process and exiting whenever an error occurs. 

## Page previews

<!-- Add the specific pages that your PR changes here -->

