### PR TITLE
Update github link in header

### DIFF
--- a/docs/.vuepress/configs/theme.ts
+++ b/docs/.vuepress/configs/theme.ts
@@ -14,7 +14,7 @@ export const themeOptions: ThemeOptions = {
     navbarLayout,
     sidebar: sidebarEn,
     toc: true,
-    repo: "https://github.com/eventstore",
+    repo: "https://github.com/kurrent-io",
     repoLabel: "GitHub",
     repoDisplay: true,
     contributors: false,


### PR DESCRIPTION
Currently links to Event Store Placeholder page

