### PR TITLE
fix: correct article usage with "Kurrent" and "KurrentDB" in documentation

### DIFF
--- a/docs/cloud/dedicated/automation/pulumi.md
+++ b/docs/cloud/dedicated/automation/pulumi.md
@@ -33,7 +33,7 @@ pulumi plugin install resource eventstorecloud v0.2.3 \
 The following configuration points are available for the `eventstorecloud` provider:
 
 - `eventstorecloud:organizationId` - the organization ID for an existing organization in Kurrent Cloud
-- `eventstorecloud:token` - a valid refresh token for an Kurrent Cloud account with admin access to the organization
+- `eventstorecloud:token` - a valid refresh token for a Kurrent Cloud account with admin access to the organization
 
 ### Node.js (Java/TypeScript)
 

--- a/docs/cloud/dedicated/automation/terraform.md
+++ b/docs/cloud/dedicated/automation/terraform.md
@@ -249,7 +249,7 @@ Here is an example how to initiate a peering from Kurrent Cloud to your own AWS 
 
 ### Managed KurrentDB
 
-Use the `eventstorecloud_managed_cluster` resource to provision an KurrentDB cluster or instance. You will need the [Project](#projects) and the [Network](#networks) resource information from previously created resources.
+Use the `eventstorecloud_managed_cluster` resource to provision a KurrentDB cluster or instance. You will need the [Project](#projects) and the [Network](#networks) resource information from previously created resources.
 
 #### Arguments
 

--- a/docs/cloud/dedicated/getting-started/private-access/aws.md
+++ b/docs/cloud/dedicated/getting-started/private-access/aws.md
@@ -5,7 +5,7 @@ order: 2
 
 # Amazon Web Services
 
-For AWS customers, Kurrent Cloud allows provisioning an KurrentDB cluster in the same cloud. You can create a cluster in the same region to ensure the lowest latency.
+For AWS customers, Kurrent Cloud allows provisioning a KurrentDB cluster in the same cloud. You can create a cluster in the same region to ensure the lowest latency.
 
 Pre-requisites:
 - You have an organization registered in Cloud console

--- a/docs/cloud/dedicated/getting-started/private-access/azure.md
+++ b/docs/cloud/dedicated/getting-started/private-access/azure.md
@@ -4,7 +4,7 @@ order: 2
 
 # Microsoft Azure
 
-For Microsoft Azure customers, Kurrent Cloud allows provisioning an KurrentDB cluster in the same cloud. You can create a cluster in the same region to ensure the lowest latency.
+For Microsoft Azure customers, Kurrent Cloud allows provisioning a KurrentDB cluster in the same cloud. You can create a cluster in the same region to ensure the lowest latency.
 
 ::: warning Azure considerations
 Microsoft Azure has a few nuances that must be considered when using Kurrent Cloud with Azure. We listed all currently known limitations [below on this page](#considerations-for-microsoft-azure). Please ensure you are aware of them before starting to use KurrentDB in Azure.

--- a/docs/cloud/dedicated/getting-started/private-access/gcp.md
+++ b/docs/cloud/dedicated/getting-started/private-access/gcp.md
@@ -4,7 +4,7 @@ order: 3
 
 # Google Cloud Platform
 
-For Google Cloud customers, Kurrent Cloud allows provisioning an KurrentDB cluster in the same cloud. You can create a cluster in the same region to ensure the lowest latency.
+For Google Cloud customers, Kurrent Cloud allows provisioning a KurrentDB cluster in the same cloud. You can create a cluster in the same region to ensure the lowest latency.
 
 Pre-requisites:
 - You have an organization registered in Cloud console

--- a/docs/cloud/dedicated/guides/kubernetes.md
+++ b/docs/cloud/dedicated/guides/kubernetes.md
@@ -7,7 +7,7 @@ Below, you can find instructions for connecting workloads running cloud-managed 
 
 ## AWS Elastic Kubernetes Services
 
-In this section, you find instructions on how to set up an AWS Elastic Kubernetes Services (EKS) cluster, so it can connect to an KurrentDB cluster in Kurrent Cloud. As a prerequisite, you have experience with Kubernetes, AWS and networking in Kubernetes, as well as in AWS cloud platform.
+In this section, you find instructions on how to set up an AWS Elastic Kubernetes Services (EKS) cluster, so it can connect to a KurrentDB cluster in Kurrent Cloud. As a prerequisite, you have experience with Kubernetes, AWS and networking in Kubernetes, as well as in AWS cloud platform.
 
 EKS clusters require at least two subnets, which are connected to internet using an Internet Gateway. Both subnets must have the auto-assign public IP setting enabled, otherwise the node group won't get properly provisioned.
 
@@ -64,7 +64,7 @@ At this moment, any workload deployed to the EKS cluster should be able to conne
 
 ## Google Kubernetes Engine
 
-In this section, you find instructions on how to set up a Google Kubernetes Engine (GKE) cluster, so it can connect to an KurrentDB cluster in Kurrent Cloud. As a prerequisite, you have experience with Kubernetes, GKE and networking in Kubernetes as well as in Google Cloud Platform (GCP).
+In this section, you find instructions on how to set up a Google Kubernetes Engine (GKE) cluster, so it can connect to a KurrentDB cluster in Kurrent Cloud. As a prerequisite, you have experience with Kubernetes, GKE and networking in Kubernetes as well as in Google Cloud Platform (GCP).
 
 Before you provision a cluster in Kurrent Cloud, you need to have a network, to which the cluster nodes will connect. Nodes in the cluster will get IP addresses from the specified network CIDR.
 
@@ -162,7 +162,7 @@ The overall network topology would look like this, when we complement the initia
 
 ## Azure Kubernetes Services
 
-In this section, you find instructions on how to set up an Azure Kubernetes Services (AKS) cluster, so it can connect to an KurrentDB cluster in Kurrent Cloud. As a prerequisite, you have experience with Kubernetes, Azure and networking in Kubernetes as well as in Azure Cloud platform.
+In this section, you find instructions on how to set up an Azure Kubernetes Services (AKS) cluster, so it can connect to a KurrentDB cluster in Kurrent Cloud. As a prerequisite, you have experience with Kubernetes, Azure and networking in Kubernetes as well as in Azure Cloud platform.
 
 Before you provision a cluster in Kurrent Cloud, you need to have a network, to which the cluster nodes will connect. Nodes in the cluster will get IP addresses from the specified network CIDR block.
 


### PR DESCRIPTION
This PR addresses grammatical issues that occurred during the rebranding from "Event Store" to "Kurrent". The main issue was incorrect article usage - using "an KurrentDB" instead of "a KurrentDB" since "Kurrent" starts with a consonant sound.

### Changes:

- Fixed article usage in multiple documentation files
- Corrected instances of "an Kurrent" to "a Kurrent"
- Corrected instances of "an KurrentDB" to "a KurrentDB"

### Files modified:

- kubernetes.md
- gcp.md
- azure.md
- aws.md
- terraform.md
- pulumi.md