### PR TITLE
fix: change artifactId for java client

### DIFF
--- a/docs/clients/grpc/getting-started.md
+++ b/docs/clients/grpc/getting-started.md
@@ -56,21 +56,21 @@ TypeScript Declarations are included in the package.
 
 #### Java
 
-Add the `db-client-java` dependency to your Maven or Gradle project. 
+Add the `kurrentdb-client` dependency to your Maven or Gradle project. 
 
 ::: tabs
 @tab Maven
 ```xml
 <dependency>
   <groupId>io.kurrent</groupId>
-  <artifactId>db-client-java</artifactId>
+  <artifactId>kurrentdb-client</artifactId>
   <version>1.0.0</version>
 </dependency>
 ```
 
 @tab Gradle
 ```groovy
-implementation 'io.kurrent:db-client-java:1.0.0'
+implementation 'io.kurrent:kurrentdb-client:1.0.0'
 ```
 
 For the most recent version of the KurrentDB client package, see [Maven Central](https://mvnrepository.com/artifact/io.kurrent/kurrentdb-client).

--- a/docs/clients/grpc/projections.md
+++ b/docs/clients/grpc/projections.md
@@ -42,21 +42,21 @@ pnpm add @kurrent/kurrentdb-client
 
 ### Java
 
-Add the `db-client-java` dependency to your project using Maven or Gradle.
+Add the `kurrentdb-client` dependency to your project using Maven or Gradle.
 
 ::: tabs
 @tab Maven
 ```xml
 <dependency>
   <groupId>io.kurrent</groupId>
-  <artifactId>db-client-java</artifactId>
+  <artifactId>kurrentdb-client</artifactId>
   <version>1.0.0</version>
 </dependency>
 ```
 
 @tab Gradle
 ```
-implementation 'io.kurrent:db-client-java:1.0.0'
+implementation 'io.kurrent:kurrentdb-client:1.0.0'
 ```
 
 For the most recent version of the KurrentDB client package, see [Maven Central](https://mvnrepository.com/artifact/io.kurrent/kurrentdb-client).

--- a/docs/getting-started/quickstart/README.md
+++ b/docs/getting-started/quickstart/README.md
@@ -248,7 +248,7 @@ kurrentdbclient==1.0.19
 ```xml
 <dependency>
    <groupId>io.kurrent</groupId>
-   <artifactId>db-client-java</artifactId>
+   <artifactId>kurrentdb-client</artifactId>
    <version>1.0.0</version>
 </dependency>
 ```


### PR DESCRIPTION
This PR addresses wrong arti factIdissues that occurred during the rebranding from "Event Store" to "Kurrent". The main issue was incorrect article usage - using "db-client-java" instead of "kurrentdb-client" .

## Description
- Fixed article usage in multiple documentation files
- Corrected instances of "db-client-java" to "kurrentdb-client"

## Page previews

<!-- Add the specific pages that your PR changes here -->

