### PR TITLE
[DEV-813] Improve seo plugin version detection

### DIFF
--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -114,6 +114,7 @@ export default defineClientConfig({
         });
         const operatorLatest = __VERSIONS__.all.filter(x => x.id === 'kubernetes-operator')[0].versions[0].version;
         addDynamicRoute("/server/kubernetes-operator", to => `/server/kubernetes-operator/${operatorLatest}/getting-started/`);
+        addDynamicRoute("/server/kubernetes-operator/latest/:pathMatch(.*)*", to => to.path.replace(/^\/server\/kubernetes-operator\/latest/, `/server/kubernetes-operator/${operatorLatest}`));
         addDynamicRoute("/server/kubernetes-operator/:version", to => `/server/kubernetes-operator/${to.params.version}/getting-started/`);
 
         // Clients routes


### PR DESCRIPTION
The version detection was only looking at the 2nd path segment, which worked fine for `/server/v25.0` but broke for nested paths like `/clients/dotnet/v1.0` where the version is in the 3rd segment.

also all client pages were getting the generic "Client" category instead of more specific ones like ".NET Client" or "Java Client".

## what changed

### flexible version detection
switched from hardcoded segment positions to regex-based detection that finds versions anywhere in the path:

```typescript
// before: assumed version is always at segments[2]
const version = segments[2];

// after: finds version wherever it is
const versionIndex = segments.findIndex((s, i) => i > 1 && /^(v\d+(\.\d+)*|\d+\.\d+)$/.test(s));
```

### better category mapping
now we get specific categories instead of generic ones:
- `.NET Client` instead of just "Client"
- `Java Client`, `Python Client`, etc.
- `Legacy TCP .NET Client` for the older stuff

makes search and filtering way more useful.

### code cleanup
simplified the logic and removed some unnecessary complexity while keeping all the same functionality.

Also added missing redirect for k8 operator

## examples

```
/server/v5/introduction.html          -> excluded from SEO
/cloud/introduction.html              -> category: "Cloud"
/server/v25.0/quick-start/            -> category: "Server", version: "v25.0"
/clients/dotnet/v1.0/getting-started -> category: ".NET Client", version: "v1.0"
/clients/tcp/dotnet/21.2/quick-tour   -> category: "Legacy TCP .NET Client", version: "21.2"
```

category and version will now be added to "es:category" and "es:version" meta tags in the html page headers. 