### PR TITLE
Add Azure capacity constraints FAQ and update cloud docs

### DIFF
--- a/docs/cloud/automation/README.md
+++ b/docs/cloud/automation/README.md
@@ -19,4 +19,4 @@ You can use any of those tools to automate any operation accessible from the con
 [cloud console tokens]:https://console.kurrent.cloud/authentication-tokens
 [cloud console organizations]:https://console.kurrent.cloud/organizations
 [pulumi]: https://www.pulumi.com/registry/packages/eventstorecloud/
-[terraform]: https://registry.terraform.io/providers/EventStore/eventstorecloud/latest
+[terraform]: https://registry.terraform.io/providers/kurrent-io/kurrentcloud/latest

--- a/docs/cloud/automation/terraform.md
+++ b/docs/cloud/automation/terraform.md
@@ -1,5 +1,5 @@
 ---
-terraform_current_version: 2.0.0
+terraform_current_version: 2.0.2
 order: 1
 ---
 

--- a/docs/cloud/faq.md
+++ b/docs/cloud/faq.md
@@ -28,7 +28,7 @@ We have a [replication tool](guides/migration.md), which is available now. It ha
 
 ## KurrentDB features unavailable in Kurrent Cloud
 
-The following features are available with local KurrentDB server deployments only and are not available in Kurrent Cloud:
+The following features are available with self-managed KurrentDB server deployments only and are not available in Kurrent Cloud:
 
 * Archiving  
 * Direct access to configuration  

--- a/docs/cloud/faq.md
+++ b/docs/cloud/faq.md
@@ -26,6 +26,21 @@ We don't support switching clusters from private to publicly accessible or vice 
 
 We have a [replication tool](guides/migration.md), which is available now. It has certain limitations, especially with performance. Get in touch, so we can help you to analyse your setup and requirements, before we can recommend using the replication tool.
 
+## KurrentDB features unavailable in Kurrent Cloud
+
+The following features are available with local KurrentDB server deployments only and are not available in Kurrent Cloud:
+
+* Archiving  
+* Direct access to configuration  
+* Encryption at rest  
+* LDAP authentication  
+* Logs download  
+* OAuth authentication  
+* OpenTelemetry exporter  
+* Read-only replicas  
+* Redaction  
+* x.509 user certificates
+
 ## Performance
 
 #### Do you have indicative performance benchmarks for the offered cluster sizes?
@@ -203,6 +218,42 @@ If the cluster DNS name resolves using an external DNS server, but your local DN
 - On a home network, routers typically configure clients to use the DNS servers provided by your Internet provider, which could be blocking such queries
     - You can reconfigure your router to configure clients on your network to use public DNS servers like `1.1.1.1` or `8.8.8.8`
     - You can also change the DNS configuration of your local machine to use public DNS servers like `1.1.1.1` or `8.8.8.8`
+
+### Cluster Creation Failed: Azure Capacity Constraints
+
+#### What Happened
+
+Your cluster creation failed because Azure returned an error that the specific virtual machine SKU required for the instance size you requested lacks sufficient capacity in that region for your subscription.
+
+#### Why This Happens
+
+Each Kurrent Cloud customer is assigned a dedicated Azure subscription. Azure VM SKU availability varies based on:
+
+- **Subscription-level capacity**: Azure allocates capacity per subscription, and some SKUs may not be available for all subscriptions in all regions.
+- **Regional capacity**: Certain VM sizes may be temporarily or permanently constrained in specific regions due to high demand.
+- **Availability zone constraints**: Some SKUs may be available in a region but not in all availability zones.
+
+This is an Azure platform limitation, not a Kurrent Cloud issue.
+
+#### Quick Workarounds
+
+1. **Try a different instance size**: Select a different instance size when creating the cluster. If you requested a specific size (e.g., `F1`), try an alternative (e.g., `C4`).
+
+2. **Try a different topology**: If you requested a three-node cluster, consider whether a single-node cluster would work for development/testing purposes.
+
+3. **Try a different region**: Create the cluster in a different Azure region where the desired virtual machine type may have available capacity.
+
+#### If You Need a Specific Configuration
+
+If your use case requires a specific configuration in a specific region:
+
+1. **Contact Kurrent Cloud Support**: Let us know the exact instance type, topology, and region you need.
+2. **We will request capacity from Microsoft**: Our team can submit a capacity request to Azure on your behalf. Note that fulfillment depends on Azure capacity availability and there is no guaranteed timeline.
+3. **Monitor for updates**: We will notify you once the capacity becomes available or if alternative options are recommended.
+
+#### Deleting the Failed Cluster
+
+The failed cluster will be in a `Defunct` state. You can delete it through the Kurrent Cloud console or CLI to clean up the resource.
 
 ## Operational characteristics of Kurrent Cloud
 

--- a/docs/cloud/getting-started/README.md
+++ b/docs/cloud/getting-started/README.md
@@ -1,7 +1,7 @@
 ---
 dir:
     link: true
-    order: 1
+    order: 2
 ---
 
 # Getting started
@@ -14,7 +14,7 @@ Clusters can be provisioned with public access enabled or restrict access to pri
 
 ### Public access
 
-For public access, the provisioning process is straightforward. You can go to the Clusters screen and click on the **New cluster** button. From there, select **Dedicated** as the infrastructure type. A Network and IP Access List will be created and the cluster will be deployed.
+For public access, the provisioning process is straightforward. You can go to the Clusters screen and click on the **New cluster** button. Fill in the form values, then a network and IP Access List will be created and the cluster will be deployed.
 
 See the [Public Access Clusters](public.md) guide to get started.
 

--- a/docs/cloud/getting-started/private-access/aws.md
+++ b/docs/cloud/getting-started/private-access/aws.md
@@ -35,12 +35,6 @@ Click on the **New cluster** button to begin the cluster creation process.
 
 Provide a descriptive name for the cluster in the **Cluster name** field.
 
-### Infrastructure type
-
-![Infrastructure type](../images/infra-type-dedicated.png)
-
-Select the `Dedicated` infrastructure type.
-
 ### Network
 
 ![Create a network](images/aws/aws-new-cluster-private-network.png)

--- a/docs/cloud/getting-started/private-access/azure.md
+++ b/docs/cloud/getting-started/private-access/azure.md
@@ -38,12 +38,6 @@ Click on the **New cluster** button to begin the cluster creation process.
 
 Provide a descriptive name for the cluster in the **Cluster name** field.
 
-### Infrastructure type
-
-![Infrastructure type](../images/infra-type-dedicated.png)
-
-Select the `Dedicated` infrastructure type.
-
 ### Network
 
 ![Create a network](images/azure/azure-new-cluster-network.png)

--- a/docs/cloud/getting-started/private-access/gcp.md
+++ b/docs/cloud/getting-started/private-access/gcp.md
@@ -30,12 +30,6 @@ Click on the **New cluster** button to begin the cluster creation process.
 
 Provide a descriptive name for the cluster in the **Cluster name** field.
 
-### Infrastructure type
-
-![Infrastructure type](../images/infra-type-dedicated.png)
-
-Select the `Dedicated` infrastructure type.
-
 ### Network
 
 ![Create a network](images/gcp/gcp-new-cluster-network.png)

--- a/docs/cloud/getting-started/public.md
+++ b/docs/cloud/getting-started/public.md
@@ -3,7 +3,7 @@ title: Public Access Clusters
 order: 2
 ---
 
-With Kurrent Cloud, provisioning KurrentDB clusters with public access on dedicated infrastructure is simple.
+With Kurrent Cloud, provisioning KurrentDB clusters with public access is simple.
 
 Pre-requisites:
 - You have an organization registered in Cloud console
@@ -22,12 +22,6 @@ In the Kurrent Cloud console, go to the [project context](../../introduction.md#
 ![Cluster name](images/new-cluster-name.png)
 
 Provide a descriptive name for the cluster in the **Cluster name** field.
-
-### Infrastructure type
-
-![Infrastructure type](images/infra-type-dedicated.png)
-
-Select the `Dedicated` infrastructure type.
 
 ### Network
 

--- a/docs/cloud/introduction.md
+++ b/docs/cloud/introduction.md
@@ -13,26 +13,7 @@ Not using Kurrent Cloud and want to learn more? Find more information and sign u
 
 As a customer of Kurrent Cloud, you get access to the [Cloud console](https://console.kurrent.cloud), where you can provision and manage KurrentDB clusters, backup and restore your data, and establish the connection between Kurrent Cloud networks and your own cloud infrastructure.
 
-Kurrent Cloud operations can be automated using the [Terraform provider](https://github.com/kurrent-io/terraform-provider-eventstorecloud), [Pulumi provider](https://www.pulumi.com/registry/packages/eventstorecloud/), and the [CLI tool](https://github.com/kurrent-io/esc) which is built on top of the same API.
-
-## What is dedicated infrastructure?
-
-With this option, KurrentDB clusters are hosted on dedicated compute infrastructure, ensuring that all resources are exclusively allocated to you. This setup is ideal for running production workloads that demand consistent performance and guaranteed resource availability.
-
-## KurrentDB features unavailable in Kurrent Cloud
-
-The following features are available with local KurrentDB server deployments only and are not available in Kurrent Cloud:
-
-* Archiving  
-* Direct access to configuration  
-* Encryption at rest  
-* LDAP authentication  
-* Logs download  
-* OAuth authentication  
-* OpenTelemetry exporter  
-* Read-only replicas  
-* Redaction  
-* x.509 user certificates
+Kurrent Cloud operations can be automated using the [Terraform provider](https://github.com/kurrent-io/terraform-provider-kurrentcloud), [Pulumi provider](https://www.pulumi.com/registry/packages/eventstorecloud/), and the [CLI tool](https://github.com/kurrent-io/esc) which is built on top of the same API.
 
 ## Cloud quick start
 
@@ -102,4 +83,4 @@ Within the project context, you can manage project clusters, backups, networks, 
 
 ### Provision a cluster
 
-You are now ready to start provisioning cloud resources with Kurrent Cloud. Please proceed to the [Getting Started guide](dedicated/getting-started/README.md) to learn how to provision your first cluster.
+You are now ready to start provisioning cloud resources with Kurrent Cloud. Please proceed to the [Getting Started guide](getting-started/README.md) to learn how to provision your first cluster.

--- a/docs/dev-center/tutorials/Kafka_Sink.md
+++ b/docs/dev-center/tutorials/Kafka_Sink.md
@@ -10,7 +10,7 @@ This step-by-step tutorial guides you through configuring and deploying a **Kafk
 #### Prerequisites:
 
 * A KurrentDB cluster with an active license key.  
-  * This tutorial uses a cluster provisioned on a [Public Network](https://docs.kurrent.io/cloud/dedicated/networking/public-network.html) of [Kurrent Cloud](https://docs.kurrent.io/cloud/introduction.html)  
+  * This tutorial uses a cluster provisioned on a [Public Network](/cloud/networking/public-network.html) of [Kurrent Cloud](/cloud/introduction.html)  
 * A [Confluent Cloud](http://confluent.cloud) Kafka cluster with an API key that can write to a topic (e.g., `loans`).  
 * Basic command-line knowledge (e.g., using `curl` for API requests).  
 * Access to KurrentDB UI and Confluent Cloud UI to monitor events.


### PR DESCRIPTION
## Summary
- Add FAQ section explaining Azure VM SKU capacity constraint failures with workarounds and support guidance
- Move "KurrentDB features unavailable in Kurrent Cloud" list from introduction page to FAQ
- Remove outdated "Infrastructure type" step from all cluster creation guides
- Update Terraform provider registry link and version (2.0.0 → 2.0.2)
- Fix relative link paths in introduction and Kafka Sink tutorial