### PR TITLE
Replace Cookiebot with Usercentrics (Web API route)

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -81,20 +81,11 @@ export default defineUserConfig({
     },
     theme: hopeTheme(themeOptions, {custom: true}),
     head: [
-        // Cookiebot banner
+        // Usercentrics CMP
         ['script', {
-            id: 'Cookiebot',
-            src: 'https://consent.cookiebot.com/uc.js',
-            'data-cbid': 'ee971b30-e872-46e8-b421-706ef26d9dcc',
-            'data-blockingmode': 'manual',
-            type: 'text/javascript',
-        }],
-
-        // Cookiebot declaration
-        ['script', {
-            id: 'CookieDeclaration',
-            src: 'https://consent.cookiebot.com/ee971b30-e872-46e8-b421-706ef26d9dcc/cd.js',
-            type: 'text/javascript',
+            id: 'usercentrics-cmp',
+            src: 'https://web.cmp.usercentrics.eu/ui/loader.js',
+            'data-settings-id': 'ArWRikBAz-iKhj',
             async: true,
         }],
 


### PR DESCRIPTION
## Summary

Replaces Cookiebot with Usercentrics as the consent management platform (CMP) across the docs site.

## Changes

**CMP script (`config.ts`)**
- Removed Cookiebot script and cookie declaration tags
- Added Usercentrics CMP loader (`web.cmp.usercentrics.eu/ui/loader.js`)

**Consent layer (`consent.ts`)**
- Replaced synchronous `Cookiebot.consent.statistics` check with async Usercentrics `UC_UI.getServicesBaseInfo()` API
- Split single `hasStatisticsConsent()` into two category-specific functions:
  - `hasFunctionalConsent()` — used by PostHog
  - `hasMarketingConsent()` — used by Reo.dev

**PostHog integration (`usePosthog.ts`)**
- Switched from `hasStatisticsConsent` to `hasFunctionalConsent`
- Replaced `CookiebotOnAccept` / `CookiebotOnDecline` / `CookiebotOnConsentReady` listeners with `UC_CONSENT` and `UC_UI_INITIALIZED`
- Updated initialization to handle async consent check

**Reo.dev integration (`useReoDev.ts`)**
- Switched from `hasStatisticsConsent` to `hasMarketingConsent`
- Same event listener migration as PostHog

**Client entry (`client.ts`)**
- `captureEvent` and consent checks are now `async`
- First-pageview-on-consent logic listens to `UC_CONSENT` and `UC_UI_INITIALIZED` instead of `CookiebotOnAccept`

## Notes

- All consent checks are now **async** since the Usercentrics `getServicesBaseInfo()` API returns a Promise
- The Usercentrics Browser UI API docs note that `getServices` was removed in favor of `getServicesBaseInfo` — this PR uses the current API